### PR TITLE
feat(nirjas): Add continuous single line as multiline & bug fixes

### DIFF
--- a/extractor/binder.py
+++ b/extractor/binder.py
@@ -21,6 +21,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 import re
+from itertools import groupby
+from operator import itemgetter
 
 
 def readSingleLine(file, regex):
@@ -47,6 +49,25 @@ def readSingleLine(file, regex):
 
     return content, total_lines, blank_lines, line_of_comments
                 
+def contSingleLines(data):
+    lines, startLine, endLine, output = [], [], [], []
+    content = ""
+    for i in data[0]:
+        lines.append(i[0])
+
+    for a, b in groupby(enumerate(lines), lambda x : x[0] - x[1]):
+        temp = list(map(itemgetter(1), b))
+        content = ""
+
+        if len(temp)>1:
+            startLine.append(temp[0])
+            endLine.append(temp[-1])
+            for i in temp:
+                comment = [x[1] for x in data[0] if x[0] == i]
+                [data[0].remove(x) for x in data[0] if x[0] == i]
+                content = content + ' ' + comment[0]
+            output.append(content)
+    return data, startLine, endLine, output
 
 def readMultiLineSame(file, syntax: str):
     lines, output, startLine, endLine = [], [], [], []
@@ -67,7 +88,7 @@ def readMultiLineSame(file, syntax: str):
 
             if copy:
                 lines_of_comment += 1
-                content = content + line.replace('\n', '')
+                content = content + line.replace('\n', ' ')
 
             output = [s.strip("'''") for s in output]
         
@@ -94,7 +115,7 @@ def readMultiLineDiff(file, startSyntax: str, endSyntax: str):
                 endLine.append(lineNumber)
             if copy:
                 line_of_comments += 1
-                content = content + line.replace('\n','')
+                content = content + line.replace('\n',' ')
             if not line.strip():
                 blank_lines += 1
         line_of_comments += len(output)

--- a/extractor/languages/c.py
+++ b/extractor/languages/c.py
@@ -20,12 +20,13 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from binder import readSingleLine, readMultiLineSame, readMultiLineDiff, CommentSyntax
+from extractor.binder import *
 
 def cExtractor(file):
     result = CommentSyntax()
     result1 = result.doubleSlash(file)
     result2 = result.slashStar(file)
+    result4 = contSingleLines(result1)
     file = file.split("/")
     output = {
         "metadata": [{
@@ -37,11 +38,20 @@ def cExtractor(file):
         "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
         }],
         "single_line_comment": [],
+        "cont_single_line_comment": [],
         "multi_line_comment": []
     }
+
+    if result4:
+        result1 = result4[0]
+
     if result1:
         for i in result1[0]:
             output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+
+    if result4:
+        for idx,i in enumerate(result4[1]):
+            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
 
     if result2:
         for idx,i in enumerate(result2[0]):

--- a/extractor/languages/c_sharp.py
+++ b/extractor/languages/c_sharp.py
@@ -20,12 +20,13 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from binder import readSingleLine, readMultiLineSame, readMultiLineDiff, CommentSyntax
+from extractor.binder import *
 
 def c_sharpExtractor(file):
     result = CommentSyntax()
     result1 = result.doubleSlash(file)
     result2 = result.slashStar(file)
+    result4 = contSingleLines(result1)
     file = file.split("/")
     output = {
         "metadata": [{
@@ -37,11 +38,20 @@ def c_sharpExtractor(file):
         "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
         }],
         "single_line_comment": [],
+        "cont_single_line_comment": [],
         "multi_line_comment": []
     }
+
+    if result4:
+        result1 = result4[0]
+
     if result1:
         for i in result1[0]:
             output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+
+    if result4:
+        for idx,i in enumerate(result4[1]):
+            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
 
     if result2:
         for idx,i in enumerate(result2[0]):

--- a/extractor/languages/cpp.py
+++ b/extractor/languages/cpp.py
@@ -20,12 +20,13 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from binder import readSingleLine, readMultiLineSame, readMultiLineDiff, CommentSyntax
+from extractor.binder import *
 
 def cppExtractor(file):
     result = CommentSyntax()
     result1 = result.doubleSlash(file)
     result2 = result.slashStar(file)
+    result4 = contSingleLines(result1)
     file = file.split("/")
     output = {
         "metadata": [{
@@ -37,11 +38,20 @@ def cppExtractor(file):
         "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
         }],
         "single_line_comment": [],
+        "cont_single_line_comment": [],
         "multi_line_comment": []
     }
+
+    if result4:
+        result1 = result4[0]
+
     if result1:
         for i in result1[0]:
             output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+
+    if result4:
+        for idx,i in enumerate(result4[1]):
+            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
 
     if result2:
         for idx,i in enumerate(result2[0]):

--- a/extractor/languages/css.py
+++ b/extractor/languages/css.py
@@ -20,7 +20,7 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from binder import readSingleLine, readMultiLineSame, readMultiLineDiff, CommentSyntax
+from extractor.binder import *
 
 def cssExtractor(file):
     output = CommentSyntax()

--- a/extractor/languages/go.py
+++ b/extractor/languages/go.py
@@ -20,12 +20,13 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from binder import readSingleLine, readMultiLineSame, readMultiLineDiff, CommentSyntax
+from extractor.binder import *
 
 def goExtractor(file):
     result = CommentSyntax()
     result1 = result.doubleSlash(file)
     result2 = result.slashStar(file)
+    result4 = contSingleLines(result1)
     file = file.split("/")
     output = {
         "metadata": [{
@@ -37,11 +38,20 @@ def goExtractor(file):
         "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
         }],
         "single_line_comment": [],
+        "cont_single_line_comment": [],
         "multi_line_comment": []
     }
+
+    if result4:
+        result1 = result4[0]
+
     if result1:
         for i in result1[0]:
             output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+
+    if result4:
+        for idx,i in enumerate(result4[1]):
+            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
 
     if result2:
         for idx,i in enumerate(result2[0]):

--- a/extractor/languages/haskell.py
+++ b/extractor/languages/haskell.py
@@ -20,12 +20,14 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from binder import readSingleLine, readMultiLineSame, readMultiLineDiff, CommentSyntax
+from extractor.binder import *
+
 
 def haskellExtractor(file):
     result = CommentSyntax()
     result1 = result.doubleDash(file)
     result2 = result.curlybracesDash(file)
+    result4 = contSingleLines(result1)
     file = file.split("/")
     output = {
         "metadata": [{
@@ -37,11 +39,20 @@ def haskellExtractor(file):
         "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
         }],
         "single_line_comment": [],
+        "cont_single_line_comment": [],
         "multi_line_comment": []
     }
+
+    if result4:
+        result1 = result4[0]
+
     if result1:
         for i in result1[0]:
             output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+
+    if result4:
+        for idx,i in enumerate(result4[1]):
+            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
 
     if result2:
         for idx,i in enumerate(result2[0]):

--- a/extractor/languages/html.py
+++ b/extractor/languages/html.py
@@ -20,12 +20,13 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from binder import readSingleLine, readMultiLineSame, readMultiLineDiff, CommentSyntax
+from extractor.binder import *
 
 def htmlExtractor(file):
     result = CommentSyntax()
     result1 = result.gtExclamationDash(file)
     result2 = result.slashStar(file)
+    result4 = contSingleLines(result1)
     file = file.split("/")
     output = {
         "metadata": [{
@@ -37,11 +38,20 @@ def htmlExtractor(file):
         "sloc": result1[4]-(result1[3]+result2[3]+result1[5])
         }],
         "single_line_comment": [],
+        "cont_single_line_comment": [],
         "multi_line_comment": []
     }
+
+    if result4:
+        result1 = result4[0]
+
     if result1:
         for i in result1[0]:
             output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+
+    if result4:
+        for idx,i in enumerate(result4[1]):
+            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
 
     if result2:
         for idx,i in enumerate(result2[0]):

--- a/extractor/languages/java.py
+++ b/extractor/languages/java.py
@@ -20,12 +20,13 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from binder import readSingleLine, readMultiLineSame, readMultiLineDiff, CommentSyntax
+from extractor.binder import *
 
 def javaExtractor(file):
     result = CommentSyntax()
     result1 = result.doubleSlash(file)
     result2 = result.slashStar(file)
+    result4 = contSingleLines(result1)
     file = file.split("/")
     output = {
         "metadata": [{
@@ -37,11 +38,20 @@ def javaExtractor(file):
         "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
         }],
         "single_line_comment": [],
+        "cont_single_line_comment": [],
         "multi_line_comment": []
     }
+
+    if result4:
+        result1 = result4[0]
+
     if result1:
         for i in result1[0]:
             output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+
+    if result4:
+        for idx,i in enumerate(result4[1]):
+            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
 
     if result2:
         for idx,i in enumerate(result2[0]):

--- a/extractor/languages/javascript.py
+++ b/extractor/languages/javascript.py
@@ -20,12 +20,13 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from binder import readSingleLine, readMultiLineSame, readMultiLineDiff, CommentSyntax
+from extractor.binder import *
 
 def javascriptExtractor(file):
     result = CommentSyntax()
     result1 = result.doubleSlash(file)
     result2 = result.slashStar(file)
+    result4 = contSingleLines(result1)
     file = file.split("/")
     output = {
         "metadata": [{
@@ -37,11 +38,20 @@ def javascriptExtractor(file):
         "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
         }],
         "single_line_comment": [],
+        "cont_single_line_comment": [],
         "multi_line_comment": []
     }
+
+    if result4:
+        result1 = result4[0]
+
     if result1:
         for i in result1[0]:
             output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+
+    if result4:
+        for idx,i in enumerate(result4[1]):
+            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
 
     if result2:
         for idx,i in enumerate(result2[0]):

--- a/extractor/languages/kotlin.py
+++ b/extractor/languages/kotlin.py
@@ -20,12 +20,13 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from binder import readSingleLine, readMultiLineSame, readMultiLineDiff, CommentSyntax
+from extractor.binder import *
 
 def kotlinExtractor(file):
     result = CommentSyntax()
     result1 = result.doubleSlash(file)
     result2 = result.slashStar(file)
+    result4 = contSingleLines(result1)
     file = file.split("/")
     output = {
         "metadata": [{
@@ -37,11 +38,20 @@ def kotlinExtractor(file):
         "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
         }],
         "single_line_comment": [],
+        "cont_single_line_comment": [],
         "multi_line_comment": []
     }
+
+    if result4:
+        result1 = result4[0]
+
     if result1:
         for i in result1[0]:
             output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+
+    if result4:
+        for idx,i in enumerate(result4[1]):
+            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
 
     if result2:
         for idx,i in enumerate(result2[0]):

--- a/extractor/languages/matlab.py
+++ b/extractor/languages/matlab.py
@@ -20,12 +20,13 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from binder import readSingleLine, readMultiLineSame, readMultiLineDiff, CommentSyntax
+from extractor.binder import *
 
 def matlabExtractor(file):
     result = CommentSyntax()
     result2 = result.percentageCurlybraces(file)
     result1 = result.percentage(file)
+    result4 = contSingleLines(result1)
     file = file.split("/")
     output = {
         "metadata": [{
@@ -37,11 +38,20 @@ def matlabExtractor(file):
         "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
         }],
         "single_line_comment": [],
+        "cont_single_line_comment": [],
         "multi_line_comment": []
     }
+
+    if result4:
+        result1 = result4[0]
+
     if result1:
         for i in result1[0]:
             output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+
+    if result4:
+        for idx,i in enumerate(result4[1]):
+            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
 
     if result2:
         for idx,i in enumerate(result2[0]):

--- a/extractor/languages/perl.py
+++ b/extractor/languages/perl.py
@@ -20,12 +20,13 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from binder import readSingleLine, readMultiLineSame, readMultiLineDiff, CommentSyntax
+from extractor.binder import *
 
 def perlExtractor(file):
     result = CommentSyntax()
     result1 = result.hash(file)
     result2 = result.beginCut(file)
+    result4 = contSingleLines(result1)
     file = file.split("/")
     output = {
         "metadata": [{
@@ -37,11 +38,20 @@ def perlExtractor(file):
         "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
         }],
         "single_line_comment": [],
+        "cont_single_line_comment": [],
         "multi_line_comment": []
     }
+
+    if result4:
+        result1 = result4[0]
+
     if result1:
         for i in result1[0]:
             output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+
+    if result4:
+        for idx,i in enumerate(result4[1]):
+            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
 
     if result2:
         for idx,i in enumerate(result2[0]):

--- a/extractor/languages/php.py
+++ b/extractor/languages/php.py
@@ -20,12 +20,13 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from binder import readSingleLine, readMultiLineSame, readMultiLineDiff, CommentSyntax
+from extractor.binder import *
 
 def phpExtractor(file):
     result = CommentSyntax()
     result1 = result.doubleSlash(file)
     result2 = result.slashStar(file)
+    result4 = contSingleLines(result1)
     file = file.split("/")
     output = {
         "metadata": [{
@@ -37,11 +38,20 @@ def phpExtractor(file):
         "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
         }],
         "single_line_comment": [],
+        "cont_single_line_comment": [],
         "multi_line_comment": []
     }
+
+    if result4:
+        result1 = result4[0]
+
     if result1:
         for i in result1[0]:
             output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+
+    if result4:
+        for idx,i in enumerate(result4[1]):
+            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
 
     if result2:
         for idx,i in enumerate(result2[0]):

--- a/extractor/languages/python.py
+++ b/extractor/languages/python.py
@@ -20,7 +20,7 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from binder import readSingleLine, readMultiLineSame, readMultiLineDiff, CommentSyntax
+from extractor.binder import *
 
 
 def pythonExtractor(file):
@@ -28,6 +28,7 @@ def pythonExtractor(file):
     result1 = result.hash(file)
     result2 = result.singleQuotes(file)
     result3 = result.doubleQuotes(file)
+    result4 = contSingleLines(result1)
     file = file.split("/")
     output = {
         "metadata": [{
@@ -39,11 +40,21 @@ def pythonExtractor(file):
         "sloc": result1[1]-(result1[3]+result2[3]+result3[3]+result1[2])
         }],
         "single_line_comment": [],
+        "cont_single_line_comment": [],
         "multi_line_comment": []
     }
+
+
+    if result4:
+        result1 = result4[0]
+
     if result1:
         for i in result1[0]:
             output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+
+    if result4:
+        for idx,i in enumerate(result4[1]):
+            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
 
     if result2:
         for idx,i in enumerate(result2[0]):

--- a/extractor/languages/r.py
+++ b/extractor/languages/r.py
@@ -20,7 +20,7 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from binder import readSingleLine, readMultiLineSame, readMultiLineDiff, CommentSyntax
+from extractor.binder import *
 
 def rExtractor(file):
     result = CommentSyntax()

--- a/extractor/languages/ruby.py
+++ b/extractor/languages/ruby.py
@@ -20,12 +20,14 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from binder import readSingleLine, readMultiLineSame, readMultiLineDiff, CommentSyntax
+from extractor.binder import *
+
 
 def rubyExtractor(file):
     result = CommentSyntax()
     result1 = result.hash(file)
     result2 = result.beginEnd(file)
+    result4 = contSingleLines(result1)
     file = file.split("/")
     output = {
         "metadata": [{
@@ -37,11 +39,20 @@ def rubyExtractor(file):
         "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
         }],
         "single_line_comment": [],
+        "cont_single_line_comment": [],
         "multi_line_comment": []
     }
+
+    if result4:
+        result1 = result4[0]
+
     if result1:
         for i in result1[0]:
             output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+
+    if result4:
+        for idx,i in enumerate(result4[1]):
+            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
 
     if result2:
         for idx,i in enumerate(result2[0]):

--- a/extractor/languages/rust.py
+++ b/extractor/languages/rust.py
@@ -20,12 +20,13 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from binder import readSingleLine, readMultiLineSame, readMultiLineDiff, CommentSyntax
+from extractor.binder import *
 
 def rustExtractor(file):
     result = CommentSyntax()
     result1 = result.doubleSlash(file)
     result2 = result.slashStar(file)
+    result4 = contSingleLines(result1)
     file = file.split("/")
     output = {
         "metadata": [{
@@ -37,11 +38,20 @@ def rustExtractor(file):
         "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
         }],
         "single_line_comment": [],
+        "cont_single_line_comment": [],
         "multi_line_comment": []
     }
+
+    if result4:
+        result1 = result4[0]
+
     if result1:
         for i in result1[0]:
             output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+
+    if result4:
+        for idx,i in enumerate(result4[1]):
+            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
 
     if result2:
         for idx,i in enumerate(result2[0]):

--- a/extractor/languages/scala.py
+++ b/extractor/languages/scala.py
@@ -20,12 +20,14 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from binder import readSingleLine, readMultiLineSame, readMultiLineDiff, CommentSyntax
+from extractor.binder import *
+
 
 def scalaExtractor(file):
     result = CommentSyntax()
     result1 = result.doubleSlash(file)
     result2 = result.slashStar(file)
+    result4 = contSingleLines(result1)
     file = file.split("/")
     output = {
         "metadata": [{
@@ -37,11 +39,20 @@ def scalaExtractor(file):
         "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
         }],
         "single_line_comment": [],
+        "cont_single_line_comment": [],
         "multi_line_comment": []
     }
+
+    if result4:
+        result1 = result4[0]
+
     if result1:
         for i in result1[0]:
             output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+
+    if result4:
+        for idx,i in enumerate(result4[1]):
+            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
 
     if result2:
         for idx,i in enumerate(result2[0]):

--- a/extractor/languages/shell.py
+++ b/extractor/languages/shell.py
@@ -20,7 +20,7 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from binder import readSingleLine, readMultiLineSame, readMultiLineDiff, CommentSyntax
+from extractor.binder import *
 
 def shellExtractor(file):
     result = CommentSyntax()

--- a/extractor/languages/swift.py
+++ b/extractor/languages/swift.py
@@ -20,12 +20,14 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from binder import readSingleLine, readMultiLineSame, readMultiLineDiff, CommentSyntax
+from extractor.binder import *
+
 
 def swiftExtractor(file):
     result = CommentSyntax()
     result1 = result.doubleSlash(file)
     result2 = result.slashStar(file)
+    result4 = contSingleLines(result1)
     file = file.split("/")
     output = {
         "metadata": [{
@@ -37,11 +39,20 @@ def swiftExtractor(file):
         "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
         }],
         "single_line_comment": [],
+        "cont_single_line_comment": [],
         "multi_line_comment": []
     }
+
+    if result4:
+        result1 = result4[0]
+
     if result1:
         for i in result1[0]:
             output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+
+    if result4:
+        for idx,i in enumerate(result4[1]):
+            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
 
     if result2:
         for idx,i in enumerate(result2[0]):

--- a/extractor/main.py
+++ b/extractor/main.py
@@ -24,8 +24,8 @@ import os
 import json
 import argparse
 
-from binder import *
-from languages import *
+from extractor.binder import *
+from extractor.languages import *
 
 
 class CommentExtractor:
@@ -107,7 +107,7 @@ def main():
         eval(func)(inputfile,string_name)
         # python.pythonSource(inputfile,string_name)
     
-    result = json.dumps(result, sort_keys=True, ensure_ascii=False, indent=4)
+    result = json.dumps(result, sort_keys=False, indent=4)
     print(result)   
 
 


### PR DESCRIPTION
# Description

Earlier continuous single-line comments were taken as separate single-line comments but they actually make a multiline comment in a sequence.

- Earlier :

```sh
# Line 1
# Line 2
code
code
# Line 5
```
Here Line 1 & Line 2 were taken as two single-line comments but they are commented sequentially which might fall into the multiline comment section.

# Solution

Introduced one new section named `cont_single_line_comment`

```json
"cont_single_line_comment": [
            {
                "start_line": 1,
                "end_line": 2,
                "comment": " Line 1 Line 2"
            }
```
