### PR TITLE
feat(reactjs): added support for react

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The Languages we support till now:
 - HTML
 - Java
 - JavaScript
+- JSX
 - Kotlin
 - MATLAB
 - Perl
@@ -62,6 +63,7 @@ The Languages we support till now:
 - Scala
 - Shell
 - Swift
+- TypeScript
 
 ## Installation
 

--- a/nirjas/main.py
+++ b/nirjas/main.py
@@ -61,6 +61,7 @@ class CommentExtractor:
             '.xml': 'html',
             '.java': 'java',
             '.js': 'javascript',
+            '.jsx': 'javascript',
             '.kt': 'kotlin',
             '.kts': 'kotlin',
             '.ktm': 'kotlin',

--- a/testScript.py
+++ b/testScript.py
@@ -28,7 +28,8 @@ def download_files(cwd):
         "https://raw.githubusercontent.com/r-lib/rlang/6dbcae3fc9af9e75b27053b28e7ae81e0717a387/R/arg.R",
         "https://raw.githubusercontent.com/ttu/csharp-tutorial/5e5f94334a8f1111ae03ef0e2d109721da6757e9/csharp-tutorial/13_Parallel.cs",
         "https://raw.githubusercontent.com/cfjedimaster/HTML-Code-Demos/89090b8b19d666e4552846a6ea27f42813c0877e/code/forms/10_validation.html",
-        "https://raw.githubusercontent.com/apache/thrift/f86845e8ed622e7e3b7c87f00f16729ee6cc524d/lib/ts/test/phantom-client.ts"
+        "https://raw.githubusercontent.com/apache/thrift/f86845e8ed622e7e3b7c87f00f16729ee6cc524d/lib/ts/test/phantom-client.ts",
+        "https://raw.githubusercontent.com/airbnb/react-with-styles/2532394bb866aaade4dc750ee94c0ff213d9b6de/src/withStyles.jsx"
     ]
 
     directory = os.path.join(cwd, "nirjas/languages/tests/TestFiles")


### PR DESCRIPTION
I mapped .jsx with JavaScript in the language map as react js [official website](https://reactjs.org/) say that it is a JavaScript library.

Though there are some note worthy differences between comments in JavaScript and React js ( JSX File )

# Comments in React Js 
## Inside functions in .js and .jsx

### Single Line comment
``` // single line comment ```

### Multi line comment
```
 /*
Multi 
line 
comment
*/ 
```

## Inside JSX
```
{
	// This is a single line comment
}
```

```
{ 
/* 
This is a 
multi 
line 
comment
*/ 
}
```

```
{ /* This is a valid comment */ }
```

```
{ // This is NOT a valid single line comment }
```

```
 // This is NOT a valid single line comment 
```

```
/* 
This is NOT a valid
multi 
line 
comment
*/ 
```

What this mean is that all valid comments will be marked as comments by nirjas but it may also mark some lines of code as comments which are not following the proper syntax of comments. 
I am open to suggestions on this