### PR TITLE
fix(core): Fix comment finding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,12 @@
 # Contributing
 
-Nirjas welcomes any form of contribution or suggestions. We believe that open source is all about collaborative working to make the project and community stronger than ever. Whether you are a beginner or an experienced developer, each and every contribution counts.
+Nirjas welcomes any form of contribution or suggestions. We believe that open
+source is all about collaborative working to make the project and community
+stronger than ever. Whether you are a beginner or an experienced developer, each
+and every contribution counts.
 
 You can contribute to Nirjas by:
-1. Opening a valid issue: visit https://github.com/fossology/nirjas/issues 
+1. Opening a valid issue: visit https://github.com/fossology/nirjas/issues
 2. Help us in closing an [existing issue](https://github.com/fossology/nirjas/issues)
 3. Open a [Pull Request](https://github.com/fossology/nirjas/pulls)
 4. Suggest us some new agent for license scanning
@@ -14,8 +17,9 @@ You can contribute to Nirjas by:
 
 
 ### Setting up a python virtual environment
-* venv (for Python 3) allow you to manage separate package installations for different projects. 
-* To create a virtual environment, go to your project’s directory and run venv. 
+* venv (for Python 3) allow you to manage separate package installations for
+  different projects.
+* To create a virtual environment, go to your project’s directory and run venv.
 
 * On macOS and Linux:
 
@@ -25,12 +29,13 @@ You can contribute to Nirjas by:
 
     `py -m venv env`
 
-> The second argument is the location to create the virtual environment. Generally, you can just create this in your project and call it env.
+> The second argument is the location to create the virtual environment.
+> Generally, you can just create this in your project and call it env.
 
 
-### Activating a virtual environment 
+### Activating a virtual environment
 * On macOS and Linux:
-    
+
     `source env/bin/activate`
 
 * On Windows:
@@ -38,20 +43,24 @@ You can contribute to Nirjas by:
     `.\env\Scripts\activate`
 
 * Leaving the virtual environment
-If you want to switch projects or otherwise leave your virtual environment, simply run:
+If you want to switch projects or otherwise leave your virtual environment,
+simply run:
 
     `deactivate`
 
 ***
 
 
-## Report a valid issue  
+## Report a valid issue
 
-Nirjas uses [GitHub's issue tracker](https://github.com/fossology/nirjas/issues). All bugs and enhancements should be listed so that we don't lose track of them, can prioritize and assign them to the relevant developer or maintainer.
+Nirjas uses [GitHub's issue tracker](https://github.com/fossology/nirjas/issues).
+All bugs and enhancements should be listed so that we don't lose track of them,
+can prioritize and assign them to the relevant developer or maintainer.
 
-Consider the following recommended best practice for writing issues, which are (Recommended but not limited to):
+Consider the following recommended best practice for writing issues, which are
+(Recommended but not limited to):
 1. More detailed description rather than one-liners
-2. Screenshots 
+2. Screenshots
 3. Providing example files and error logs
 4. How to reproduce it
 5. Details of your local system or environment that you're using
@@ -62,7 +71,7 @@ Please follow the [Coding Style](https://www.python.org/dev/peps/pep-0008/) (PEP
 
 **Not Familiar with Git?**
 
-> Invest a few minutes on our [Git Tutorial](https://github.com/fossology/fossology/wiki/Git-basic-commands) 
+> Invest a few minutes on our [Git Tutorial](https://github.com/fossology/fossology/wiki/Git-basic-commands)
 
 ### Workflow
 
@@ -110,18 +119,20 @@ feat(CosineSim): Implemented similarity score to approximately match headers
 
 Allowed types:
 
-*   **feat**: A new feature
-*   **fix**: A bug fix
-*   **docs**: Documentation only changes
-*   **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, newline, line endings, etc)
-*   **refactor**: A code change that neither fixes a bug or adds a feature
-*   **perf**: A code change that improves performance
-*   **test**: Adding missing tests
-*   **chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation
+* **feat**: A new feature
+* **fix**: A bug fix
+* **docs**: Documentation only changes
+* **style**: Changes that do not affect the meaning of the code (white-space,
+  formatting, missing semi-colons, newline, line endings, etc)
+* **refactor**: A code change that neither fixes a bug or adds a feature
+* **perf**: A code change that improves performance
+* **test**: Adding missing tests
+* **chore**: Changes to the build process or auxiliary tools and libraries such
+  as documentation generation
 
-## Making a change with a pull request 
+## Making a change with a pull request
 
-Pull requests with patches, improvements and new features are a great help. 
+Pull requests with patches, improvements and new features are a great help.
 
 #### 1. Fork the project, clone your fork, and add the remote:
 
@@ -133,7 +144,7 @@ git clone https://github.com/<USERNAME>/Nirjas.git
 cd Nirjas
 
 # Assign the original repo to a remote called "upstream"
-git remote add upstream git@github.com:fossology/Nirjas.git 
+git remote add upstream git@github.com:fossology/Nirjas.git
 ```
 #### 2. Get the latest changes from upstream:
 
@@ -144,24 +155,25 @@ git pull upstream master
 
 #### 3. Create a new branch from the main master branch to contain your changes:
 
-```sh 
-git checkout -b <topic-branch-name> 
+```sh
+git checkout -b <topic-branch-name>
 ```
 
 #### 4. Add and Commit your changes
 
 ```sh
-git add <path/to/modified/file/> 
+git add <path/to/modified/file/>
 git commit -m "write a commit message"
 ```
-> Examine the status of your working tree at each step to see if everything is clean
+> Examine the status of your working tree at each step to see if everything is
+> clean
 >```sh
 > git status
 > ```
 
 Push your topic branch up to your fork:
 ```sh
-git push origin <topic-branch-name> 
+git push origin <topic-branch-name>
 ```
 
 #### 5. Open a Pull Request with a clear title and description against the master branch.
@@ -169,18 +181,21 @@ git push origin <topic-branch-name>
 [Open a Pull Request.](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)
 
 
-A maintainer/developer will review and might suggest some changes before merging them into the repository.
+A maintainer/developer will review and might suggest some changes before merging
+them into the repository.
 
-Success!! :tada:  Well done! :bowing_man: 
+Success!! :tada:  Well done! :bowing_man:
 
 
 ***
 
 
-## A Special Note 
+## A Special Note
 
-Thank you for reading through and we look forward to your valuable contribution! :smiley:  
+Thank you for reading through and we look forward to your valuable contribution!
+:smiley:
 
-We appreciate the hard work and time of our contributors who have built and maintained the project! :raised_hands:
+We appreciate the hard work and time of our contributors who have built and
+maintained the project! :raised_hands:
 
-You are Awesome! :star2: :star_struck: 
+You are Awesome! :star2: :star_struck:

--- a/LICENSE
+++ b/LICENSE
@@ -55,7 +55,7 @@ modified by someone else and passed on, the recipients should know
 that what they have is not the original version, so that the original
 author's reputation will not be affected by problems that might be
 introduced by others.
-
+
   Finally, software patents pose a constant threat to the existence of
 any free program.  We wish to make sure that a company cannot
 effectively restrict the users of a free program by obtaining a
@@ -111,7 +111,7 @@ modification follow.  Pay close attention to the difference between a
 "work based on the library" and a "work that uses the library".  The
 former contains code derived from the library, whereas the latter must
 be combined with the library in order to run.
-
+
                   GNU LESSER GENERAL PUBLIC LICENSE
    TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
@@ -158,7 +158,7 @@ Library.
   You may charge a fee for the physical act of transferring a copy,
 and you may at your option offer warranty protection in exchange for a
 fee.
-
+
   2. You may modify your copy or copies of the Library or any portion
 of it, thus forming a work based on the Library, and copy and
 distribute such modifications or work under the terms of Section 1
@@ -216,7 +216,7 @@ instead of to this License.  (If a newer version than version 2 of the
 ordinary GNU General Public License has appeared, then you can specify
 that version instead if you wish.)  Do not make any other change in
 these notices.
-
+
   Once this change is made in a given copy, it is irreversible for
 that copy, so the ordinary GNU General Public License applies to all
 subsequent copies and derivative works made from that copy.
@@ -267,7 +267,7 @@ Library will still fall under Section 6.)
 distribute the object code for the work under the terms of Section 6.
 Any executables containing that work also fall under Section 6,
 whether or not they are linked directly with the Library itself.
-
+
   6. As an exception to the Sections above, you may also combine or
 link a "work that uses the Library" with the Library to produce a
 work containing portions of the Library, and distribute that work
@@ -329,7 +329,7 @@ restrictions of other proprietary libraries that do not normally
 accompany the operating system.  Such a contradiction means you cannot
 use both them and the Library together in an executable that you
 distribute.
-
+
   7. You may place library facilities that are a work based on the
 Library side-by-side in a single library together with other library
 facilities not covered by this License, and distribute such a combined
@@ -370,7 +370,7 @@ subject to these terms and conditions.  You may not impose any further
 restrictions on the recipients' exercise of the rights granted herein.
 You are not responsible for enforcing compliance by third parties with
 this License.
-
+
   11. If, as a consequence of a court judgment or allegation of patent
 infringement or for any other reason (not limited to patent issues),
 conditions are imposed on you (whether by court order, agreement or
@@ -422,7 +422,7 @@ conditions either of that version or of any later version published by
 the Free Software Foundation.  If the Library does not specify a
 license version number, you may choose any version ever published by
 the Free Software Foundation.
-
+
   14. If you wish to incorporate parts of the Library into other free
 programs whose distribution conditions are incompatible with these,
 write to the author to ask for permission.  For software which is
@@ -456,7 +456,7 @@ SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGES.
 
                      END OF TERMS AND CONDITIONS
-
+
            How to Apply These Terms to Your New Libraries
 
   If you develop a new library, and you want it to be of the greatest

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">✨ 🍰 ✨</p>
 
 <p align="center">
-    
+
 ![python version](https://img.shields.io/badge/Python-v3%2B-blue)
 ![Unit Tests](https://github.com/fossology/Nirjas/workflows/Unit%20Tests/badge.svg)
 ![status](https://img.shields.io/pypi/status/Nirjas)
@@ -19,7 +19,7 @@
 
 ## Description
 
-A source code file usually contains various vital information such as license text, function/class documentation, code/logic explanation, etc in the form of comments (block & line). 
+A source code file usually contains various vital information such as license text, function/class documentation, code/logic explanation, etc in the form of comments (block & line).
 
 Nirjas is a fully dedicated python library to extract the comments and source code out of your file(s). The extracted comments can be processed in various ways to detect licenses, generate documentation, process info, etc.
 
@@ -31,7 +31,7 @@ Apart from that the library serves you with all the required metadata about your
 Installing Python on Linux machines:
 
 ```sh
-$ sudo apt-get install python3 python3-pip 
+$ sudo apt-get install python3 python3-pip
 ```
 
 For macOS and Windows, packages are available at [Python.org](https://www.python.org/downloads/)
@@ -102,16 +102,16 @@ Upgrade already installed Nirjas library to the latest version from [PyPI](https
 pip3 install --upgrade Nirjas
 ```
 
-### Install using source 
+### Install using source
 
-If you are interested in contributing to [Nirjas](https://github.com/fossology/Nirjas) development, running the latest source code, or just like to build everything yourself, it is not difficult to install & build [Nirjas](https://github.com/fossology/Nirjas) from the source. 
+If you are interested in contributing to [Nirjas](https://github.com/fossology/Nirjas) development, running the latest source code, or just like to build everything yourself, it is not difficult to install & build [Nirjas](https://github.com/fossology/Nirjas) from the source.
 
 * Fork the [repo](https://github.com/fossology/Nirjas)
 
 * Clone on your local system
 
 ```sh
-git clone https://github.com/fossology/Nirjas.git 
+git clone https://github.com/fossology/Nirjas.git
 ```
 
 * Change directory
@@ -126,7 +126,7 @@ cd Nirjas/
 pip3 install .
 ```
 
-> This will install Nirjas on your system. 
+> This will install Nirjas on your system.
 
 
 * Check if Nirjas is installed correctly or get help, Run:
@@ -180,11 +180,11 @@ We maintain our entire documentation at GitHub wiki.
 Feel free to switch from `code` to `wiki` or just click here - [Nirjas Documentation](https://github.com/fossology/Nirjas/wiki)
 
 
-## Contributing 
+## Contributing
 
 All contributions, bug reports, bug fixes, documentation improvements, enhancements, and ideas are welcome.
 
-A detailed overview on how to contribute can be found in the [contributing guide](/CONTRIBUTING.md). 
+A detailed overview on how to contribute can be found in the [contributing guide](/CONTRIBUTING.md).
 
 Feel free to ask questions or discuss suggestions on [Slack](https://fossology.slack.com/)
 

--- a/nirjas/languages/c.py
+++ b/nirjas/languages/c.py
@@ -21,46 +21,43 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
+
 
 def cExtractor(file):
     result = CommentSyntax()
-    result1 = result.doubleSlash(file)
-    result2 = result.slashStar(file)
-    result4 = contSingleLines(result1)
+    single_line_comment = result.doubleSlash(file)
+    multiline_comment = result.slashStar(file)
+    cont_single_line_comment = contSingleLines(single_line_comment)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "C",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3]+result2[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "cont_single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'C'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3] + multiline_comment[3]
+    output.blank_lines = single_line_comment[2]
 
-    if result4:
-        result1 = result4[0]
+    if cont_single_line_comment:
+        single_line_comment = cont_single_line_comment[0]
 
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result4:
-        for idx,i in enumerate(result4[1]):
-            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
+    for idx, i in enumerate(cont_single_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_single_line_comment[1][idx], cont_single_line_comment[2][idx],
+            cont_single_line_comment[3][idx]))
 
-    if result2:
-        try:
-            for idx,i in enumerate(result2[0]):
-                output['multi_line_comment'].append({"start_line": result2[0][idx], "end_line": result2[1][idx], "comment": result2[2][idx]})
-        except:
-            pass
+    try:
+        for idx, i in enumerate(multiline_comment[0]):
+            output.multi_line_comment.append(MultiLine(multiline_comment[0][idx],
+                                                       multiline_comment[1][idx],
+                                                       multiline_comment[2][idx]))
+    except:
+        pass
 
     return output
+
 
 def cSource(file, newFile: str):
     closingCount = 0

--- a/nirjas/languages/c.py
+++ b/nirjas/languages/c.py
@@ -59,29 +59,35 @@ def cExtractor(file):
     return output
 
 
-def cSource(file, newFile: str):
-    closingCount = 0
+def cSource(file, new_file: str):
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                if line.strip() == '/*':
-                    closingCount+=1
+            for line in f:
+                content = ""
+                found = False
+                if '/*' in line:
+                    pos = line.find('/*')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if line.strip() == '*/':
-                    closingCount+=1
-                    copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if copy:
-                    if line.strip() != '/*' and line.strip() != '*/':
-                        Templine = line.replace(" ","")
-                        if Templine[0:2] != "//":            # Syntax for single line comment
-                            f1.write(line)
+                    found = True
+                if '*/' in line:
+                    content = content + line[line.rfind('*/') + 2:]
+                    line = content
+                    copy = True
+                    found = True
+                if '//' in line:
+                    if line[line.find('//') - 1] != ':':
+                        line = line[:line.find('//')].rstrip() + '\n'
+                    elif line[line.rfind('//') - 1] != ':':
+                        line = line[:line.rfind('//')].rstrip() + '\n'
+                    content = line
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/c_sharp.py
+++ b/nirjas/languages/c_sharp.py
@@ -21,68 +21,64 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
+
 
 def c_sharpExtractor(file):
     result = CommentSyntax()
-    result1 = result.doubleSlash(file)
-    result2 = result.slashStar(file)
-    result4 = contSingleLines(result1)
+    single_line_comment = result.doubleSlash(file)
+    multiline_comment = result.slashStar(file)
+    cont_single_line_comment = contSingleLines(single_line_comment)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "C#",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3]+result2[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "cont_single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'C#'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3] + multiline_comment[3]
+    output.blank_lines = single_line_comment[2]
 
-    if result4:
-        result1 = result4[0]
+    if cont_single_line_comment:
+        single_line_comment = cont_single_line_comment[0]
 
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result4:
-        for idx,i in enumerate(result4[1]):
-            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
+    for idx, i in enumerate(cont_single_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_single_line_comment[1][idx], cont_single_line_comment[2][idx],
+            cont_single_line_comment[3][idx]))
 
-    if result2:
-        for idx,i in enumerate(result2[0]):
-            output['multi_line_comment'].append({"start_line": result2[0][idx], "end_line": result2[1][idx], "comment": result2[2][idx]})
-        
+    for idx, i in enumerate(multiline_comment[0]):
+        output.multi_line_comment.append(MultiLine(multiline_comment[0][idx],
+                                                   multiline_comment[1][idx],
+                                                   multiline_comment[2][idx]))
 
     return output
 
-def c_sharpSource(file, newFile: str):
-    closingCount = 0
+
+def c_sharpSource(file, new_file: str):
+    closing_count = 0
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
+            for line_number, line in enumerate(f, start=1):
                 if line.strip() == '/*':
-                    closingCount+=1
+                    closing_count += 1
                     copy = False
-                    if closingCount%2 == 0:
+                    if closing_count % 2 == 0:
                         copy = True
 
                 if line.strip() == '*/':
-                    closingCount+=1
+                    closing_count += 1
                     copy = False
-                    if closingCount%2 == 0:
+                    if closing_count % 2 == 0:
                         copy = True
 
                 if copy:
                     if line.strip() != '/*' and line.strip() != '*/':
-                        Templine = line.replace(" ","")
-                        if Templine[0:2] != "//":            # Syntax for single line comment
+                        Templine = line.replace(" ", "")
+                        if Templine[0:2] != "//":  # Syntax for single line comment
                             f1.write(line)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/c_sharp.py
+++ b/nirjas/languages/c_sharp.py
@@ -57,28 +57,34 @@ def c_sharpExtractor(file):
 
 
 def c_sharpSource(file, new_file: str):
-    closing_count = 0
     copy = True
     with open(new_file, 'w+') as f1:
-        with open(file) as f:
-            for line_number, line in enumerate(f, start=1):
-                if line.strip() == '/*':
-                    closing_count += 1
+        with open(file, 'r') as f:
+            for line in f:
+                content = ""
+                found = False
+                if '/*' in line:
+                    pos = line.find('/*')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closing_count % 2 == 0:
-                        copy = True
-
-                if line.strip() == '*/':
-                    closing_count += 1
-                    copy = False
-                    if closing_count % 2 == 0:
-                        copy = True
-
-                if copy:
-                    if line.strip() != '/*' and line.strip() != '*/':
-                        Templine = line.replace(" ", "")
-                        if Templine[0:2] != "//":  # Syntax for single line comment
-                            f1.write(line)
+                    found = True
+                if '*/' in line:
+                    content = content + line[line.rfind('*/') + 2:]
+                    line = content
+                    copy = True
+                    found = True
+                if '//' in line:
+                    if line[line.find('//') - 1] != ':':
+                        line = line[:line.find('//')].rstrip() + '\n'
+                    elif line[line.rfind('//') - 1] != ':':
+                        line = line[:line.rfind('//')].rstrip() + '\n'
+                    content = line
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
     return new_file

--- a/nirjas/languages/cpp.py
+++ b/nirjas/languages/cpp.py
@@ -59,29 +59,35 @@ def cppExtractor(file):
     return output
 
 
-def cppSource(file, newFile: str):
-    closingCount = 0
+def cppSource(file, new_file: str):
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                if line.strip() == '/*':
-                    closingCount+=1
+            for line in f:
+                content = ""
+                found = False
+                if '/*' in line:
+                    pos = line.find('/*')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if line.strip() == '*/':
-                    closingCount+=1
-                    copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if copy:
-                    if line.strip() != '/*' and line.strip() != '*/':
-                        Templine = line.replace(" ","")
-                        if Templine[0:2] != "//":            # Syntax for single line comment
-                            f1.write(line)
+                    found = True
+                if '*/' in line:
+                    content = content + line[line.rfind('*/') + 2:]
+                    line = content
+                    copy = True
+                    found = True
+                if '//' in line:
+                    if line[line.find('//') - 1] != ':':
+                        line = line[:line.find('//')].rstrip() + '\n'
+                    elif line[line.rfind('//') - 1] != ':':
+                        line = line[:line.rfind('//')].rstrip() + '\n'
+                    content = line
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/cpp.py
+++ b/nirjas/languages/cpp.py
@@ -21,47 +21,43 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
+
 
 def cppExtractor(file):
     result = CommentSyntax()
-    result1 = result.doubleSlash(file)
-    result2 = result.slashStar(file)
-    result4 = contSingleLines(result1)
+    single_line_comment = result.doubleSlash(file)
+    multiline_comment = result.slashStar(file)
+    cont_single_line_comment = contSingleLines(single_line_comment)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "C++",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3]+result2[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "cont_single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'C++'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3] + multiline_comment[3]
+    output.blank_lines = single_line_comment[2]
 
-    if result4:
-        result1 = result4[0]
+    if cont_single_line_comment:
+        single_line_comment = cont_single_line_comment[0]
 
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result4:
-        for idx,i in enumerate(result4[1]):
-            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
+    for idx, i in enumerate(cont_single_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_single_line_comment[1][idx], cont_single_line_comment[2][idx],
+            cont_single_line_comment[3][idx]))
 
-    if result2:
-        try:
-            for idx,i in enumerate(result2[0]):
-                output['multi_line_comment'].append({"start_line": result2[0][idx], "end_line": result2[1][idx], "comment": result2[2][idx]})
-        except:
-            pass
-        
+    try:
+        for idx, i in enumerate(multiline_comment[0]):
+            output.multi_line_comment.append(MultiLine(multiline_comment[0][idx],
+                                                       multiline_comment[1][idx],
+                                                       multiline_comment[2][idx]))
+    except:
+        pass
 
     return output
+
 
 def cppSource(file, newFile: str):
     closingCount = 0

--- a/nirjas/languages/css.py
+++ b/nirjas/languages/css.py
@@ -21,30 +21,28 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
+
 
 def cssExtractor(file):
-    output = CommentSyntax()
-    result1 = output.slashStar(file)
+    result = CommentSyntax()
+    multiline_comment = result.slashStar(file)
     file = file.split("/")
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'CSS'
+    output.total_lines = multiline_comment[4]
+    output.total_lines_of_comments = multiline_comment[3]
+    output.blank_lines = multiline_comment[5]
 
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "CSS",
-        "total_lines": result1[4],
-        "total_lines_of_comments": result1[3],
-        "blank_lines": result1[5],
-        "sloc": result1[4]-(result1[3]+result1[5])
-        }],
-        "single_line_comment": [],
-        "multi_line_comment": []
-    }
-    if result1:
-        try:
-            for idx,i in enumerate(result1[0]):
-                output['multi_line_comment'].append({"start_line": result1[0][idx], "end_line": result1[1][idx], "comment": result1[2][idx]})
-        except:
-            pass
+    try:
+        for idx, i in enumerate(multiline_comment[0]):
+            output.multi_line_comment.append(MultiLine(multiline_comment[0][idx],
+                                                       multiline_comment[1][idx],
+                                                       multiline_comment[2][idx]))
+    except:
+        pass
+
     return output
 
 

--- a/nirjas/languages/css.py
+++ b/nirjas/languages/css.py
@@ -21,7 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import ScanOutput, MultiLine
 
 
 def cssExtractor(file):
@@ -46,29 +46,28 @@ def cssExtractor(file):
     return output
 
 
-def cssSource(file, newFile: str):
-    closingCount = 0
+def cssSource(file, new_file: str):
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                if line.strip() == '/*':
-                    closingCount+=1
+            for line in f:
+                content = ""
+                found = False
+                if '/*' in line:
+                    pos = line.find('/*')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if line.strip() == '*/':
-                    closingCount+=1
-                    copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if copy:
-                    if line.strip() != '/*' and line.strip() != '*/':
-                        # Templine = line.replace(" ","")
-                        # if Templine[0:2] != "syntax":            # Syntax for single line comment
-                        f1.write(line)
+                    found = True
+                if '*/' in line:
+                    content = content + line[line.rfind('*/') + 2:]
+                    line = content
+                    copy = True
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/dart.py
+++ b/nirjas/languages/dart.py
@@ -21,59 +21,56 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
+
 
 def dartExtractor(file):
     result = CommentSyntax()
-    result1 = result.doubleNotTripleSlash(file)
-    result2 = result.slashStar(file)
-    result3 = result.tripleSlash(file)
-    result4 = contSingleLines(result1)
-    result5 = contSingleLines(result3)
+    single_line_comment = result.doubleNotTripleSlash(file)
+    doc_comment = result.tripleSlash(file)
+    multiline_comment = result.slashStar(file)
+    cont_single_line_comment = contSingleLines(single_line_comment)
+    cont_doc_line_comment = contSingleLines(doc_comment)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "Dart",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3]+result2[3]+result3[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result2[3]+result3[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "cont_single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'Dart'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3] + multiline_comment[3] + doc_comment[3]
+    output.blank_lines = single_line_comment[2]
 
-    if result4:
-        result1 = result4[0]
+    if cont_single_line_comment:
+        single_line_comment = cont_single_line_comment[0]
 
-    if result5:
-        result3 = result5[0]
+    if cont_doc_line_comment:
+        doc_comment = cont_doc_line_comment[0]
 
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result3:
-        for i in result3[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for i in doc_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result4:
-        for idx,i in enumerate(result4[1]):
-            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
+    for idx, i in enumerate(cont_single_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_single_line_comment[1][idx], cont_single_line_comment[2][idx],
+            cont_single_line_comment[3][idx]))
 
-    if result5:
-        for idx,i in enumerate(result5[1]):
-            output['cont_single_line_comment'].append({"start_line": result5[1][idx], "end_line": result5[2][idx], "comment": result5[3][idx]})
+    for idx, i in enumerate(cont_doc_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_doc_line_comment[1][idx], cont_doc_line_comment[2][idx],
+            cont_doc_line_comment[3][idx]))
 
-    if result2:
-        try:
-            for idx,i in enumerate(result2[0]):
-                output['multi_line_comment'].append({"start_line": result2[0][idx], "end_line": result2[1][idx], "comment": result2[2][idx]})
-        except:
-            pass
+    try:
+        for idx, i in enumerate(multiline_comment[0]):
+            output.multi_line_comment.append(MultiLine(multiline_comment[0][idx],
+                                                       multiline_comment[1][idx],
+                                                       multiline_comment[2][idx]))
+    except:
+        pass
 
     return output
+
 
 def dartSource(file, newFile: str):
     closingCount = 0
@@ -103,4 +100,4 @@ def dartSource(file, newFile: str):
 
     f.close()
     f1.close()
-    return newFile 
+    return newFile

--- a/nirjas/languages/dart.py
+++ b/nirjas/languages/dart.py
@@ -72,32 +72,40 @@ def dartExtractor(file):
     return output
 
 
-def dartSource(file, newFile: str):
-    closingCount = 0
+def dartSource(file, new_file: str):
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                if line.strip() == '/*':
-                    closingCount+=1
+            for line in f:
+                content = ""
+                found = False
+                if '/*' in line:
+                    pos = line.find('/*')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if line.strip() == '*/':
-                    closingCount+=1
-                    copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if copy:
-                    if line.strip() != '/*' and line.strip() != '*/':
-                        Templine = line.replace(" ","")
-                        if Templine[0:3] != "///":             # Syntax for single line documentation comment
-                            f1.write(line)
-                        elif Templine[0:2] != "//":            # Syntax for single line comment
-                            f1.write(line)
-
+                    found = True
+                if '*/' in line:
+                    content = content + line[line.rfind('*/') + 2:]
+                    line = content
+                    copy = True
+                    found = True
+                if '///' in line:
+                    pos = line.find('///')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
+                    found = True
+                if '//' in line:
+                    if line[line.find('//') - 1] != ':':
+                        line = line[:line.find('//')].rstrip() + '\n'
+                    elif line[line.rfind('//') - 1] != ':':
+                        line = line[:line.rfind('//')].rstrip() + '\n'
+                    content = line
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/go.py
+++ b/nirjas/languages/go.py
@@ -56,29 +56,35 @@ def goExtractor(file):
     return output
 
 
-def goSource(file, newFile: str):
-    closingCount = 0
+def goSource(file, new_file: str):
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                if line.strip() == '/*':
-                    closingCount+=1
+            for line in f:
+                content = ""
+                found = False
+                if '/*' in line:
+                    pos = line.find('/*')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if line.strip() == '*/':
-                    closingCount+=1
-                    copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if copy:
-                    if line.strip() != '/*' and line.strip() != '*/':
-                        Templine = line.replace(" ","")
-                        if Templine[0:2] != "//":            # Syntax for single line comment
-                            f1.write(line)
+                    found = True
+                if '*/' in line:
+                    content = content + line[line.rfind('*/') + 2:]
+                    line = content
+                    copy = True
+                    found = True
+                if '//' in line:
+                    if line[line.find('//') - 1] != ':':
+                        line = line[:line.find('//')].rstrip() + '\n'
+                    elif line[line.rfind('//') - 1] != ':':
+                        line = line[:line.rfind('//')].rstrip() + '\n'
+                    content = line
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/go.py
+++ b/nirjas/languages/go.py
@@ -21,44 +21,40 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
+
 
 def goExtractor(file):
     result = CommentSyntax()
-    result1 = result.doubleSlash(file)
-    result2 = result.slashStar(file)
-    result4 = contSingleLines(result1)
+    single_line_comment = result.doubleSlash(file)
+    multiline_comment = result.slashStar(file)
+    cont_single_line_comment = contSingleLines(single_line_comment)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "Go",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3]+result2[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "cont_single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'Go'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3] + multiline_comment[3]
+    output.blank_lines = single_line_comment[2]
 
-    if result4:
-        result1 = result4[0]
+    if cont_single_line_comment:
+        single_line_comment = cont_single_line_comment[0]
 
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result4:
-        for idx,i in enumerate(result4[1]):
-            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
+    for idx, i in enumerate(cont_single_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_single_line_comment[1][idx], cont_single_line_comment[2][idx],
+            cont_single_line_comment[3][idx]))
 
-    if result2:
-        for idx,i in enumerate(result2[0]):
-            output['multi_line_comment'].append({"start_line": result2[0][idx], "end_line": result2[1][idx], "comment": result2[2][idx]})
-        
+    for idx, i in enumerate(multiline_comment[0]):
+        output.multi_line_comment.append(MultiLine(multiline_comment[0][idx],
+                                                   multiline_comment[1][idx],
+                                                   multiline_comment[2][idx]))
 
     return output
+
 
 def goSource(file, newFile: str):
     closingCount = 0

--- a/nirjas/languages/haskell.py
+++ b/nirjas/languages/haskell.py
@@ -56,29 +56,31 @@ def haskellExtractor(file):
     return output
 
 
-def haskellSource(file, newFile: str):
-    closingCount = 0
+def haskellSource(file, new_file: str):
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                if line.strip() == '{-':
-                    closingCount+=1
+            for line in f:
+                content = ""
+                found = False
+                if '{-' in line:
+                    pos = line.find('{-')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if line.strip() == '-}':
-                    closingCount+=1
-                    copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if copy:
-                    if line.strip() != '{-' and line.strip() != '-}':
-                        Templine = line.replace(" ","")
-                        if Templine[0:2] != "--":            # Syntax for single line comment
-                            f1.write(line)
+                    found = True
+                if '-}' in line:
+                    content = content + line[line.rfind('-}') + 2:]
+                    line = content
+                    copy = True
+                    found = True
+                if '--' in line:
+                    content = line[:line.find('--')].rstrip() + '\n'
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/haskell.py
+++ b/nirjas/languages/haskell.py
@@ -21,45 +21,40 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
 
 
 def haskellExtractor(file):
     result = CommentSyntax()
-    result1 = result.doubleDash(file)
-    result2 = result.curlybracesDash(file)
-    result4 = contSingleLines(result1)
+    single_line_comment = result.doubleDash(file)
+    multiline_comment = result.curlybracesDash(file)
+    cont_single_line_comment = contSingleLines(single_line_comment)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "Haskell",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3]+result2[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "cont_single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'Haskell'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3] + multiline_comment[3]
+    output.blank_lines = single_line_comment[2]
 
-    if result4:
-        result1 = result4[0]
+    if cont_single_line_comment:
+        single_line_comment = cont_single_line_comment[0]
 
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result4:
-        for idx,i in enumerate(result4[1]):
-            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
+    for idx, i in enumerate(cont_single_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_single_line_comment[1][idx], cont_single_line_comment[2][idx],
+            cont_single_line_comment[3][idx]))
 
-    if result2:
-        for idx,i in enumerate(result2[0]):
-            output['multi_line_comment'].append({"start_line": result2[0][idx], "end_line": result2[1][idx], "comment": result2[2][idx]})
-        
+    for idx, i in enumerate(multiline_comment[0]):
+        output.multi_line_comment.append(MultiLine(multiline_comment[0][idx],
+                                                   multiline_comment[1][idx],
+                                                   multiline_comment[2][idx]))
 
     return output
+
 
 def haskellSource(file, newFile: str):
     closingCount = 0

--- a/nirjas/languages/html.py
+++ b/nirjas/languages/html.py
@@ -21,7 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import ScanOutput, MultiLine
 
 
 def htmlExtractor(file):
@@ -55,29 +55,39 @@ def htmlExtractor(file):
     return output
 
 
-def htmlSource(file, newFile: str):
-    closingCount = 0
+def htmlSource(file, new_file: str):
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                if line.strip() == '/*':
-                    closingCount+=1
+            for line in f:
+                content = ""
+                found = False
+                if '/*' in line:
+                    pos = line.find('/*')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if line.strip() == '*/':
-                    closingCount+=1
+                    found = True
+                if '*/' in line:
+                    content = content + line[line.rfind('*/') + 2:]
+                    line = content
+                    copy = True
+                    found = True
+                if '<!--' in line:
+                    pos = line.find('<!--')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if copy:
-                    if line.strip() != '/*' and line.strip() != '*/':
-                        Templine = line.replace(" ","")
-                        if Templine[0:2] != "<!--":            # Syntax for single line comment
-                            f1.write(line)
+                    found = True
+                if '-->' in line:
+                    content = content + line[line.rfind('-->') + 3:]
+                    line = content
+                    copy = True
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/html.py
+++ b/nirjas/languages/html.py
@@ -21,41 +21,37 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
+
 
 def htmlExtractor(file):
     result = CommentSyntax()
-    result1 = result.gtExclamationDash(file)
-    result2 = result.slashStar(file)
+    multiline_dash_comment = result.gtExclamationDash(file)
+    multiline_star_comment = result.slashStar(file)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "HTML",
-        "total_lines": result1[4],
-        "total_lines_of_comments": result1[3]+result2[3],
-        "blank_lines": result1[5],
-        "sloc": result1[4]-(result1[3]+result2[3]+result1[5])
-        }],
-        "single_line_comment": [],
-        "cont_single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'HTML'
+    output.total_lines = multiline_dash_comment[4]
+    output.total_lines_of_comments = multiline_dash_comment[3] + multiline_star_comment[3]
+    output.blank_lines = multiline_dash_comment[5]
 
+    try:
+        for idx, i in enumerate(multiline_dash_comment[0]):
+            output.multi_line_comment.append(MultiLine(
+                multiline_dash_comment[0][idx], multiline_dash_comment[1][idx],
+                multiline_dash_comment[2][idx]))
+    except:
+        pass
 
-    if result1:
-        try:
-            for idx,i in enumerate(result1[0]):
-                output['multi_line_comment'].append({"start_line": result1[0][idx], "end_line": result1[1][idx], "comment": result1[2][idx]})
-        except:
-            pass
-        
-    if result2:
-        try:
-            for idx,i in enumerate(result2[0]):
-                output['multi_line_comment'].append({"start_line": result2[0][idx], "end_line": result2[1][idx], "comment": result2[2][idx]})
-        except:
-            pass
-        
+    try:
+        for idx, i in enumerate(multiline_star_comment[0]):
+            output.multi_line_comment.append(MultiLine(
+                multiline_star_comment[0][idx], multiline_star_comment[1][idx],
+                multiline_star_comment[2][idx]))
+    except:
+        pass
+
     return output
 
 

--- a/nirjas/languages/java.py
+++ b/nirjas/languages/java.py
@@ -21,42 +21,37 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
+
 
 def javaExtractor(file):
     result = CommentSyntax()
-    result1 = result.doubleSlash(file)
-    result2 = result.slashStar(file)
-    result4 = contSingleLines(result1)
+    single_line_comment = result.doubleSlash(file)
+    multiline_comment = result.slashStar(file)
+    cont_single_line_comment = contSingleLines(single_line_comment)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "Java",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3]+result2[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "cont_single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'Java'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3] + multiline_comment[3]
+    output.blank_lines = single_line_comment[2]
 
-    if result4:
-        result1 = result4[0]
+    if cont_single_line_comment:
+        single_line_comment = cont_single_line_comment[0]
 
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result4:
-        for idx,i in enumerate(result4[1]):
-            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
+    for idx, i in enumerate(cont_single_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_single_line_comment[1][idx], cont_single_line_comment[2][idx],
+            cont_single_line_comment[3][idx]))
 
-    if result2:
-        for idx,i in enumerate(result2[0]):
-            output['multi_line_comment'].append({"start_line": result2[0][idx], "end_line": result2[1][idx], "comment": result2[2][idx]})
-
+    for idx, i in enumerate(multiline_comment[0]):
+        output.multi_line_comment.append(MultiLine(multiline_comment[0][idx],
+                                                   multiline_comment[1][idx],
+                                                   multiline_comment[2][idx]))
 
     return output
 

--- a/nirjas/languages/java.py
+++ b/nirjas/languages/java.py
@@ -56,29 +56,35 @@ def javaExtractor(file):
     return output
 
 
-def javaSource(file, newFile: str):
-    closingCount = 0
+def javaSource(file, new_file: str):
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                if line.strip() == '/*':
-                    closingCount+=1
+            for line in f:
+                content = ""
+                found = False
+                if '/*' in line:
+                    pos = line.find('/*')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if line.strip() == '*/':
-                    closingCount+=1
-                    copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if copy:
-                    if line.strip() != '/*' and line.strip() != '*/':
-                        Templine = line.replace(" ","")
-                        if Templine[0:2] != "//":            # Syntax for single line comment
-                            f1.write(line)
+                    found = True
+                if '*/' in line:
+                    content = content + line[line.rfind('*/') + 2:]
+                    line = content
+                    copy = True
+                    found = True
+                if '//' in line:
+                    if line[line.find('//') - 1] != ':':
+                        line = line[:line.find('//')].rstrip() + '\n'
+                    elif line[line.rfind('//') - 1] != ':':
+                        line = line[:line.rfind('//')].rstrip() + '\n'
+                    content = line
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/javascript.py
+++ b/nirjas/languages/javascript.py
@@ -59,29 +59,35 @@ def javascriptExtractor(file):
     return output
 
 
-def javascriptSource(file, newFile: str):
-    closingCount = 0
+def javascriptSource(file, new_file: str):
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                if line.strip() == '/*':
-                    closingCount+=1
+            for line in f:
+                content = ""
+                found = False
+                if '/*' in line:
+                    pos = line.find('/*')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if line.strip() == '*/':
-                    closingCount+=1
-                    copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if copy:
-                    if line.strip() != '/*' and line.strip() != '*/':
-                        Templine = line.replace(" ","")
-                        if Templine[0:2] != "//":            # Syntax for single line comment
-                            f1.write(line)
+                    found = True
+                if '*/' in line:
+                    content = content + line[line.rfind('*/') + 2:]
+                    line = content
+                    copy = True
+                    found = True
+                if '//' in line:
+                    if line[line.find('//') - 1] != ':':
+                        line = line[:line.find('//')].rstrip() + '\n'
+                    elif line[line.rfind('//') - 1] != ':':
+                        line = line[:line.rfind('//')].rstrip() + '\n'
+                    content = line
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/javascript.py
+++ b/nirjas/languages/javascript.py
@@ -21,45 +21,40 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
+
 
 def javascriptExtractor(file):
     result = CommentSyntax()
-    result1 = result.doubleSlash(file)
-    result2 = result.slashStar(file)
-    result4 = contSingleLines(result1)
+    single_line_comment = result.doubleSlash(file)
+    multiline_comment = result.slashStar(file)
+    cont_single_line_comment = contSingleLines(single_line_comment)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "JavaScript",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3]+result2[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "cont_single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'JavaScript'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3] + multiline_comment[3]
+    output.blank_lines = single_line_comment[2]
 
-    if result4:
-        result1 = result4[0]
+    if cont_single_line_comment:
+        single_line_comment = cont_single_line_comment[0]
 
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result4:
-        for idx,i in enumerate(result4[1]):
-            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
+    for idx, i in enumerate(cont_single_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_single_line_comment[1][idx], cont_single_line_comment[2][idx],
+            cont_single_line_comment[3][idx]))
 
-    if result2:
-        try:
-            for idx,i in enumerate(result2[0]):
-                output['multi_line_comment'].append({"start_line": result2[0][idx], "end_line": result2[1][idx], "comment": result2[2][idx]})
-        except:
-            pass
-        
+    try:
+        for idx, i in enumerate(multiline_comment[0]):
+            output.multi_line_comment.append(MultiLine(multiline_comment[0][idx],
+                                                       multiline_comment[1][idx],
+                                                       multiline_comment[2][idx]))
+    except:
+        pass
 
     return output
 

--- a/nirjas/languages/kotlin.py
+++ b/nirjas/languages/kotlin.py
@@ -56,29 +56,35 @@ def kotlinExtractor(file):
     return output
 
 
-def kotlinSource(file, newFile: str):
-    closingCount = 0
+def kotlinSource(file, new_file: str):
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                if line.strip() == '/*':
-                    closingCount+=1
+            for line in f:
+                content = ""
+                found = False
+                if '/*' in line:
+                    pos = line.find('/*')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if line.strip() == '*/':
-                    closingCount+=1
-                    copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if copy:
-                    if line.strip() != '/*' and line.strip() != '*/':
-                        Templine = line.replace(" ","")
-                        if Templine[0:2] != "//":            # Syntax for single line comment
-                            f1.write(line)
+                    found = True
+                if '*/' in line:
+                    content = content + line[line.rfind('*/') + 2:]
+                    line = content
+                    copy = True
+                    found = True
+                if '//' in line:
+                    if line[line.find('//') - 1] != ':':
+                        line = line[:line.find('//')].rstrip() + '\n'
+                    elif line[line.rfind('//') - 1] != ':':
+                        line = line[:line.rfind('//')].rstrip() + '\n'
+                    content = line
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/kotlin.py
+++ b/nirjas/languages/kotlin.py
@@ -21,42 +21,37 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
+
 
 def kotlinExtractor(file):
     result = CommentSyntax()
-    result1 = result.doubleSlash(file)
-    result2 = result.slashStar(file)
-    result4 = contSingleLines(result1)
+    single_line_comment = result.doubleSlash(file)
+    multiline_comment = result.slashStar(file)
+    cont_single_line_comment = contSingleLines(single_line_comment)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "Kotlin",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3]+result2[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "cont_single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'Kotlin'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3] + multiline_comment[3]
+    output.blank_lines = single_line_comment[2]
 
-    if result4:
-        result1 = result4[0]
+    if cont_single_line_comment:
+        single_line_comment = cont_single_line_comment[0]
 
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result4:
-        for idx,i in enumerate(result4[1]):
-            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
+    for idx, i in enumerate(cont_single_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_single_line_comment[1][idx], cont_single_line_comment[2][idx],
+            cont_single_line_comment[3][idx]))
 
-    if result2:
-        for idx,i in enumerate(result2[0]):
-            output['multi_line_comment'].append({"start_line": result2[0][idx], "end_line": result2[1][idx], "comment": result2[2][idx]})
-        
+    for idx, i in enumerate(multiline_comment[0]):
+        output.multi_line_comment.append(MultiLine(multiline_comment[0][idx],
+                                                   multiline_comment[1][idx],
+                                                   multiline_comment[2][idx]))
 
     return output
 

--- a/nirjas/languages/matlab.py
+++ b/nirjas/languages/matlab.py
@@ -21,42 +21,37 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
+
 
 def matlabExtractor(file):
     result = CommentSyntax()
-    result2 = result.percentageCurlybraces(file)
-    result1 = result.percentage(file)
-    result4 = contSingleLines(result1)
+    single_line_comment = result.percentage(file)
+    multiline_comment = result.percentageCurlybraces(file)
+    cont_single_line_comment = contSingleLines(single_line_comment)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "MATLAB",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3]+result2[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "cont_single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'Matlab'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3] + multiline_comment[3]
+    output.blank_lines = single_line_comment[2]
 
-    if result4:
-        result1 = result4[0]
+    if cont_single_line_comment:
+        single_line_comment = cont_single_line_comment[0]
 
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result4:
-        for idx,i in enumerate(result4[1]):
-            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
+    for idx, i in enumerate(cont_single_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_single_line_comment[1][idx], cont_single_line_comment[2][idx],
+            cont_single_line_comment[3][idx]))
 
-    if result2:
-        for idx,i in enumerate(result2[0]):
-            output['multi_line_comment'].append({"start_line": result2[0][idx], "end_line": result2[1][idx], "comment": result2[2][idx]})
-        
+    for idx, i in enumerate(multiline_comment[0]):
+        output.multi_line_comment.append(MultiLine(multiline_comment[0][idx],
+                                                   multiline_comment[1][idx],
+                                                   multiline_comment[2][idx]))
 
     return output
 

--- a/nirjas/languages/matlab.py
+++ b/nirjas/languages/matlab.py
@@ -32,7 +32,7 @@ def matlabExtractor(file):
     file = file.split("/")
     output = ScanOutput()
     output.filename = file[-1]
-    output.lang = 'Matlab'
+    output.lang = 'MATLAB'
     output.total_lines = single_line_comment[1]
     output.total_lines_of_comments = single_line_comment[3] + multiline_comment[3]
     output.blank_lines = single_line_comment[2]

--- a/nirjas/languages/matlab.py
+++ b/nirjas/languages/matlab.py
@@ -56,29 +56,31 @@ def matlabExtractor(file):
     return output
 
 
-def matlabSource(file, newFile: str):
-    closingCount = 0
+def matlabSource(file, new_file: str):
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                if line.strip() == '%{':
-                    closingCount+=1
+            for line in f:
+                content = ""
+                found = False
+                if '%{' in line:
+                    pos = line.find('%{')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if line.strip() == '}%':
-                    closingCount+=1
-                    copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if copy:
-                    if line.strip() != '%{' and line.strip() != '}%':
-                        Templine = line.replace(" ","")
-                        if Templine[0] != "%":            # Syntax for single line comment
-                            f1.write(line)
+                    found = True
+                if '}%' in line:
+                    content = content + line[line.rfind('}%') + 2:]
+                    line = content
+                    copy = True
+                    found = True
+                if '%' in line:
+                    content = line[:line.find('%')].rstrip() + '\n'
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/perl.py
+++ b/nirjas/languages/perl.py
@@ -56,29 +56,32 @@ def perlExtractor(file):
     return output
 
 
-def perlSource(file, newFile: str):
+def perlSource(file, new_file: str):
     closingCount = 0
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                if line.strip() == '=begin':
-                    closingCount+=1
+            for line in f:
+                content = ""
+                found = False
+                if '=begin' in line:
+                    pos = line.find('=begin')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if line.strip() == '=cut':
-                    closingCount+=1
-                    copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if copy:
-                    if line.strip() != '=begin' and line.strip() != '=cut':
-                        Templine = line.replace(" ","")
-                        if Templine[0] != "#":            # Syntax for single line comment
-                            f1.write(line)
+                    found = True
+                if '=cut' in line:
+                    content = content + line[line.rfind('=cut') + 4:]
+                    line = content
+                    copy = True
+                    found = True
+                if '#' in line:
+                    content = line[:line.find('#')].rstrip() + '\n'
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/perl.py
+++ b/nirjas/languages/perl.py
@@ -21,42 +21,37 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
+
 
 def perlExtractor(file):
     result = CommentSyntax()
-    result1 = result.hash(file)
-    result2 = result.beginCut(file)
-    result4 = contSingleLines(result1)
+    single_line_comment = result.hash(file)
+    multiline_comment = result.beginCut(file)
+    cont_single_line_comment = contSingleLines(single_line_comment)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "Perl",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3]+result2[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "cont_single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'Perl'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3] + multiline_comment[3]
+    output.blank_lines = single_line_comment[2]
 
-    if result4:
-        result1 = result4[0]
+    if cont_single_line_comment:
+        single_line_comment = cont_single_line_comment[0]
 
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result4:
-        for idx,i in enumerate(result4[1]):
-            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
+    for idx, i in enumerate(cont_single_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_single_line_comment[1][idx], cont_single_line_comment[2][idx],
+            cont_single_line_comment[3][idx]))
 
-    if result2:
-        for idx,i in enumerate(result2[0]):
-            output['multi_line_comment'].append({"start_line": result2[0][idx], "end_line": result2[1][idx], "comment": result2[2][idx]})
-        
+    for idx, i in enumerate(multiline_comment[0]):
+        output.multi_line_comment.append(MultiLine(multiline_comment[0][idx],
+                                                   multiline_comment[1][idx],
+                                                   multiline_comment[2][idx]))
 
     return output
 

--- a/nirjas/languages/php.py
+++ b/nirjas/languages/php.py
@@ -56,29 +56,35 @@ def phpExtractor(file):
     return output
 
 
-def phpSource(file, newFile: str):
-    closingCount = 0
+def phpSource(file, new_file: str):
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                if line.strip() == '/*':
-                    closingCount+=1
+            for line in f:
+                content = ""
+                found = False
+                if '/*' in line:
+                    pos = line.find('/*')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if line.strip() == '*/':
-                    closingCount+=1
-                    copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if copy:
-                    if line.strip() != '/*' and line.strip() != '*/':
-                        Templine = line.replace(" ","")
-                        if Templine[0:2] != "//":            # Syntax for single line comment
-                            f1.write(line)
+                    found = True
+                if '*/' in line:
+                    content = content + line[line.rfind('*/') + 2:]
+                    line = content
+                    copy = True
+                    found = True
+                if '//' in line:
+                    if line[line.find('//') - 1] != ':':
+                        line = line[:line.find('//')].rstrip() + '\n'
+                    elif line[line.rfind('//') - 1] != ':':
+                        line = line[:line.rfind('//')].rstrip() + '\n'
+                    content = line
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/php.py
+++ b/nirjas/languages/php.py
@@ -21,44 +21,40 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
+
 
 def phpExtractor(file):
     result = CommentSyntax()
-    result1 = result.doubleSlash(file)
-    result2 = result.slashStar(file)
-    result4 = contSingleLines(result1)
+    single_line_comment = result.doubleSlash(file)
+    multiline_comment = result.slashStar(file)
+    cont_single_line_comment = contSingleLines(single_line_comment)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "PHP",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3]+result2[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "cont_single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'PHP'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3] + multiline_comment[3]
+    output.blank_lines = single_line_comment[2]
 
-    if result4:
-        result1 = result4[0]
+    if cont_single_line_comment:
+        single_line_comment = cont_single_line_comment[0]
 
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result4:
-        for idx,i in enumerate(result4[1]):
-            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
+    for idx, i in enumerate(cont_single_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_single_line_comment[1][idx], cont_single_line_comment[2][idx],
+            cont_single_line_comment[3][idx]))
 
-    if result2:
-        for idx,i in enumerate(result2[0]):
-            output['multi_line_comment'].append({"start_line": result2[0][idx], "end_line": result2[1][idx], "comment": result2[2][idx]})
-        
+    for idx, i in enumerate(multiline_comment[0]):
+        output.multi_line_comment.append(MultiLine(multiline_comment[0][idx],
+                                                   multiline_comment[1][idx],
+                                                   multiline_comment[2][idx]))
 
     return output
+
 
 def phpSource(file, newFile: str):
     closingCount = 0

--- a/nirjas/languages/python.py
+++ b/nirjas/languages/python.py
@@ -70,29 +70,44 @@ def pythonExtractor(file):
     return output
 
 
-def pythonSource(file, newFile: str):
-    closingCount = 0
+def pythonSource(file, new_file: str):
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                if line.strip() == "'''":
-                    closingCount+=1
-                    copy = False
-                    if closingCount%2 == 0:
+            for line in f:
+                content = ""
+                found = False
+                if '"""' in line:
+                    if copy:
+                        pos = line.find('"""')
+                        content = line[:pos].rstrip()
+                        line = line[pos:]
+                        copy = False
+                        found = True
+                    else:
+                        content = content + line[line.rfind('"""') + 3:]
+                        line = content
                         copy = True
-
-                if line.strip() == '"""':
-                    closingCount+=1
-                    copy = False
-                    if closingCount%2 == 0:
+                        found = True
+                if "'''" in line:
+                    if copy:
+                        pos = line.find("'''")
+                        content = line[:pos].rstrip()
+                        line = line[pos:]
+                        copy = False
+                        found = True
+                    else:
+                        content = content + line[line.rfind("'''") + 3:]
+                        line = content
                         copy = True
-
-                if copy:
-                    if line.strip() != "'''" and line.strip() != '"""':
-                        Templine = line.replace(" ","")
-                        if Templine[0] != "#":            # Syntax for single line comment
-                            f1.write(line)
+                        found = True
+                if '#' in line:
+                    content = line[:line.find('#')].rstrip() + '\n'
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/python.py
+++ b/nirjas/languages/python.py
@@ -21,54 +21,51 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
 
 
 def pythonExtractor(file):
     result = CommentSyntax()
-    result1 = result.hash(file)
-    result2 = result.singleQuotes(file)
-    result3 = result.doubleQuotes(file)
-    result4 = contSingleLines(result1)
+    single_line_comment = result.hash(file)
+    multiline_single_comment = result.singleQuotes(file)
+    multiline_double_comment = result.doubleQuotes(file)
+    cont_single_line_comment = contSingleLines(single_line_comment)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "Python",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3]+result2[3]+result3[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result2[3]+result3[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "cont_single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'Python'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3] + multiline_single_comment[3] + multiline_double_comment[3]
+    output.blank_lines = single_line_comment[2]
 
+    if cont_single_line_comment:
+        single_line_comment = cont_single_line_comment[0]
 
-    if result4:
-        result1 = result4[0]
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for idx, i in enumerate(cont_single_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_single_line_comment[1][idx], cont_single_line_comment[2][idx],
+            cont_single_line_comment[3][idx]))
 
-    if result4:
-        for idx,i in enumerate(result4[1]):
-            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
+    try:
+        for idx, i in enumerate(multiline_single_comment[0]):
+            output.multi_line_comment.append(MultiLine(
+                multiline_single_comment[0][idx],
+                multiline_single_comment[1][idx],
+                multiline_single_comment[2][idx]))
+    except:
+        pass
 
-    if result2:
-        try:
-            for idx,i in enumerate(result2[0]):
-                output['multi_line_comment'].append({"start_line": result2[0][idx], "end_line": result2[1][idx], "comment": result2[2][idx]})
-        except:
-            pass
-        
-    if result3:
-        try:
-            for idx,i in enumerate(result3[0]):
-                output['multi_line_comment'].append({"start_line": result3[0][idx], "end_line": result3[1][idx], "comment": result3[2][idx]})
-        except:
-            pass
+    try:
+        for idx, i in enumerate(multiline_double_comment[0]):
+            output.multi_line_comment.append(MultiLine(
+                multiline_double_comment[0][idx],
+                multiline_double_comment[1][idx],
+                multiline_double_comment[2][idx]))
+    except:
+        pass
 
     return output
 
@@ -99,4 +96,3 @@ def pythonSource(file, newFile: str):
     f.close()
     f1.close()
     return newFile
-    

--- a/nirjas/languages/r.py
+++ b/nirjas/languages/r.py
@@ -21,7 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import ScanOutput, SingleLine
 
 
 def rExtractor(file):
@@ -41,15 +41,15 @@ def rExtractor(file):
     return output
 
 
-def rSource(file, newFile: str):
-    closingCount = 0
-    copy = True
-    with open(newFile, 'w+') as f1:
+def rSource(file, new_file: str):
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                Templine = line.replace(" ","")
-                if Templine[0] != "#":            # Syntax for single line comment
-                    f1.write(line)
+            for line in f:
+                content = line
+                if '#' in line:
+                    content = line[:line.find('#')].rstrip() + '\n'
+                if content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/r.py
+++ b/nirjas/languages/r.py
@@ -21,27 +21,22 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
+
 
 def rExtractor(file):
     result = CommentSyntax()
-    result1 = result.hash(file)
+    single_line_comment = result.hash(file)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "R",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "multi_line_comment": []
-    }
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
-   
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'R'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3]
+    output.blank_lines = single_line_comment[2]
+
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
     return output
 

--- a/nirjas/languages/ruby.py
+++ b/nirjas/languages/ruby.py
@@ -21,43 +21,37 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
 
 
 def rubyExtractor(file):
     result = CommentSyntax()
-    result1 = result.hash(file)
-    result2 = result.beginEnd(file)
-    result4 = contSingleLines(result1)
+    single_line_comment = result.hash(file)
+    multiline_comment = result.beginEnd(file)
+    cont_single_line_comment = contSingleLines(single_line_comment)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "Ruby",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3]+result2[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "cont_single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'Ruby'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3] + multiline_comment[3]
+    output.blank_lines = single_line_comment[2]
 
-    if result4:
-        result1 = result4[0]
+    if cont_single_line_comment:
+        single_line_comment = cont_single_line_comment[0]
 
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result4:
-        for idx,i in enumerate(result4[1]):
-            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
+    for idx, i in enumerate(cont_single_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_single_line_comment[1][idx], cont_single_line_comment[2][idx],
+            cont_single_line_comment[3][idx]))
 
-    if result2:
-        for idx,i in enumerate(result2[0]):
-            output['multi_line_comment'].append({"start_line": result2[0][idx], "end_line": result2[1][idx], "comment": result2[2][idx]})
-        
+    for idx, i in enumerate(multiline_comment[0]):
+        output.multi_line_comment.append(MultiLine(multiline_comment[0][idx],
+                                                   multiline_comment[1][idx],
+                                                   multiline_comment[2][idx]))
 
     return output
 

--- a/nirjas/languages/ruby.py
+++ b/nirjas/languages/ruby.py
@@ -56,29 +56,31 @@ def rubyExtractor(file):
     return output
 
 
-def rubySource(file, newFile: str):
-    closingCount = 0
+def rubySource(file, new_file: str):
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                if line.strip() == '=begin':
-                    closingCount+=1
+            for line in f:
+                content = ""
+                found = False
+                if '=begin' in line:
+                    pos = line.find('=begin')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if line.strip() == '=end':
-                    closingCount+=1
-                    copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if copy:
-                    if line.strip() != '=begin' and line.strip() != '=end':
-                        Templine = line.replace(" ","")
-                        if Templine[0] != "#":            # Syntax for single line comment
-                            f1.write(line)
+                    found = True
+                if '=end' in line:
+                    content = content + line[line.rfind('=end') + 4:]
+                    line = content
+                    copy = True
+                    found = True
+                if '#' in line:
+                    content = line[:line.find('#')].rstrip() + '\n'
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/rust.py
+++ b/nirjas/languages/rust.py
@@ -21,43 +21,38 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
+
 
 def rustExtractor(file):
     result = CommentSyntax()
-    result1 = result.doubleSlash(file)
-    result2 = result.slashStar(file)
-    result4 = contSingleLines(result1)
+    single_line_comment = result.doubleSlash(file)
+    multiline_comment = result.slashStar(file)
+    cont_single_line_comment = contSingleLines(single_line_comment)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "Rust",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3]+result2[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "cont_single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'Rust'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3] + multiline_comment[3]
+    output.blank_lines = single_line_comment[2]
 
-    if result4:
-        result1 = result4[0]
+    if cont_single_line_comment:
+        single_line_comment = cont_single_line_comment[0]
 
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result4:
-        for idx,i in enumerate(result4[1]):
-            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
+    for idx, i in enumerate(cont_single_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_single_line_comment[1][idx], cont_single_line_comment[2][idx],
+            cont_single_line_comment[3][idx]))
 
-    if result2:
-        for idx,i in enumerate(result2[0]):
-            output['multi_line_comment'].append({"start_line": result2[0][idx], "end_line": result2[1][idx], "comment": result2[2][idx]})
-        
-    
+    for idx, i in enumerate(multiline_comment[0]):
+        output.multi_line_comment.append(MultiLine(multiline_comment[0][idx],
+                                                   multiline_comment[1][idx],
+                                                   multiline_comment[2][idx]))
+
     return output
 
 

--- a/nirjas/languages/rust.py
+++ b/nirjas/languages/rust.py
@@ -56,29 +56,35 @@ def rustExtractor(file):
     return output
 
 
-def rustSource(file, newFile: str):
-    closingCount = 0
+def rustSource(file, new_file: str):
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                if line.strip() == '/*':
-                    closingCount+=1
+            for line in f:
+                content = ""
+                found = False
+                if '/*' in line:
+                    pos = line.find('/*')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if line.strip() == '*/':
-                    closingCount+=1
-                    copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if copy:
-                    if line.strip() != '/*' and line.strip() != '*/':
-                        Templine = line.replace(" ","")
-                        if Templine[0:2] != "//":            # Syntax for single line comment
-                            f1.write(line)
+                    found = True
+                if '*/' in line:
+                    content = content + line[line.rfind('*/') + 2:]
+                    line = content
+                    copy = True
+                    found = True
+                if '//' in line:
+                    if line[line.find('//') - 1] != ':':
+                        line = line[:line.find('//')].rstrip() + '\n'
+                    elif line[line.rfind('//') - 1] != ':':
+                        line = line[:line.rfind('//')].rstrip() + '\n'
+                    content = line
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/scala.py
+++ b/nirjas/languages/scala.py
@@ -21,43 +21,37 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
 
 
 def scalaExtractor(file):
     result = CommentSyntax()
-    result1 = result.doubleSlash(file)
-    result2 = result.slashStar(file)
-    result4 = contSingleLines(result1)
+    single_line_comment = result.doubleSlash(file)
+    multiline_comment = result.slashStar(file)
+    cont_single_line_comment = contSingleLines(single_line_comment)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "Scala",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3]+result2[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "cont_single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'Scala'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3] + multiline_comment[3]
+    output.blank_lines = single_line_comment[2]
 
-    if result4:
-        result1 = result4[0]
+    if cont_single_line_comment:
+        single_line_comment = cont_single_line_comment[0]
 
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result4:
-        for idx,i in enumerate(result4[1]):
-            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
+    for idx, i in enumerate(cont_single_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_single_line_comment[1][idx], cont_single_line_comment[2][idx],
+            cont_single_line_comment[3][idx]))
 
-    if result2:
-        for idx,i in enumerate(result2[0]):
-            output['multi_line_comment'].append({"start_line": result2[0][idx], "end_line": result2[1][idx], "comment": result2[2][idx]})
-        
+    for idx, i in enumerate(multiline_comment[0]):
+        output.multi_line_comment.append(MultiLine(multiline_comment[0][idx],
+                                                   multiline_comment[1][idx],
+                                                   multiline_comment[2][idx]))
 
     return output
 

--- a/nirjas/languages/scala.py
+++ b/nirjas/languages/scala.py
@@ -56,29 +56,35 @@ def scalaExtractor(file):
     return output
 
 
-def scalaSource(file, newFile: str):
-    closingCount = 0
+def scalaSource(file, new_file: str):
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                if line.strip() == '/*':
-                    closingCount+=1
+            for line in f:
+                content = ""
+                found = False
+                if '/*' in line:
+                    pos = line.find('/*')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if line.strip() == '*/':
-                    closingCount+=1
-                    copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if copy:
-                    if line.strip() != '/*' and line.strip() != '*/':
-                        Templine = line.replace(" ","")
-                        if Templine[0:2] != "//":            # Syntax for single line comment
-                            f1.write(line)
+                    found = True
+                if '*/' in line:
+                    content = content + line[line.rfind('*/') + 2:]
+                    line = content
+                    copy = True
+                    found = True
+                if '//' in line:
+                    if line[line.find('//') - 1] != ':':
+                        line = line[:line.find('//')].rstrip() + '\n'
+                    elif line[line.rfind('//') - 1] != ':':
+                        line = line[:line.rfind('//')].rstrip() + '\n'
+                    content = line
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/scss.py
+++ b/nirjas/languages/scss.py
@@ -21,59 +21,56 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
+
 
 def scssExtractor(file):
     result = CommentSyntax()
-    result1 = result.doubleNotTripleSlash(file)
-    result2 = result.slashStar(file)
-    result3 = result.tripleSlash(file)
-    result4 = contSingleLines(result1)
-    result5 = contSingleLines(result3)
+    single_line_comment = result.doubleNotTripleSlash(file)
+    doc_comment = result.tripleSlash(file)
+    multiline_comment = result.slashStar(file)
+    cont_single_line_comment = contSingleLines(single_line_comment)
+    cont_doc_comment = contSingleLines(doc_comment)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "Scss",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3]+result2[3]+result3[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result2[3]+result3[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "cont_single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'Scss'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3] + doc_comment[3] + multiline_comment[3]
+    output.blank_lines = single_line_comment[2]
 
-    if result4:
-        result1 = result4[0]
+    if cont_single_line_comment:
+        single_line_comment = cont_single_line_comment[0]
 
-    if result5:
-        result3 = result5[0]
+    if cont_doc_comment:
+        doc_comment = cont_doc_comment[0]
 
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result3:
-        for i in result3[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for i in doc_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result4:
-        for idx,i in enumerate(result4[1]):
-            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
+    for idx, i in enumerate(cont_single_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_single_line_comment[1][idx], cont_single_line_comment[2][idx],
+            cont_single_line_comment[3][idx]))
 
-    if result5:
-        for idx,i in enumerate(result5[1]):
-            output['cont_single_line_comment'].append({"start_line": result5[1][idx], "end_line": result5[2][idx], "comment": result5[3][idx]})
+    for idx, i in enumerate(cont_doc_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_doc_comment[1][idx], cont_doc_comment[2][idx],
+            cont_doc_comment[3][idx]))
 
-    if result2:
-        try:
-            for idx,i in enumerate(result2[0]):
-                output['multi_line_comment'].append({"start_line": result2[0][idx], "end_line": result2[1][idx], "comment": result2[2][idx]})
-        except:
-            pass
+    try:
+        for idx, i in enumerate(multiline_comment[0]):
+            output.multi_line_comment.append(MultiLine(multiline_comment[0][idx],
+                                                       multiline_comment[1][idx],
+                                                       multiline_comment[2][idx]))
+    except:
+        pass
 
     return output
+
 
 def scssSource(file, newFile: str):
     closingCount = 0
@@ -103,4 +100,4 @@ def scssSource(file, newFile: str):
 
     f.close()
     f1.close()
-    return newFile 
+    return newFile

--- a/nirjas/languages/scss.py
+++ b/nirjas/languages/scss.py
@@ -72,32 +72,40 @@ def scssExtractor(file):
     return output
 
 
-def scssSource(file, newFile: str):
-    closingCount = 0
+def scssSource(file, new_file: str):
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                if line.strip() == '/*':
-                    closingCount+=1
+            for line in f:
+                content = ""
+                found = False
+                if '/*' in line:
+                    pos = line.find('/*')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if line.strip() == '*/':
-                    closingCount+=1
-                    copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if copy:
-                    if line.strip() != '/*' and line.strip() != '*/':
-                        Templine = line.replace(" ","")
-                        if Templine[0:3] != "///":             # Syntax for single line documentation comment
-                            f1.write(line)
-                        elif Templine[0:2] != "//":            # Syntax for single line comment
-                            f1.write(line)
-
+                    found = True
+                if '*/' in line:
+                    content = content + line[line.rfind('*/') + 2:]
+                    line = content
+                    copy = True
+                    found = True
+                if '///' in line:
+                    pos = line.find('///')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
+                    found = True
+                if '//' in line:
+                    if line[line.find('//') - 1] != ':':
+                        line = line[:line.find('//')].rstrip() + '\n'
+                    elif line[line.rfind('//') - 1] != ':':
+                        line = line[:line.rfind('//')].rstrip() + '\n'
+                    content = line
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/shell.py
+++ b/nirjas/languages/shell.py
@@ -21,27 +21,31 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
+
 
 def shellExtractor(file):
     result = CommentSyntax()
-    result1 = result.hash(file)
+    single_line_comment = result.hash(file)
+    cont_single_line_comment = contSingleLines(single_line_comment)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "Shell",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "multi_line_comment": []
-    }
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'Shell'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3]
+    output.blank_lines = single_line_comment[2]
 
+    if cont_single_line_comment:
+        single_line_comment = cont_single_line_comment[0]
+
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
+
+    for idx, i in enumerate(cont_single_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_single_line_comment[1][idx], cont_single_line_comment[2][idx],
+            cont_single_line_comment[3][idx]))
 
     return output
 

--- a/nirjas/languages/shell.py
+++ b/nirjas/languages/shell.py
@@ -50,15 +50,15 @@ def shellExtractor(file):
     return output
 
 
-def shellSource(file, newFile: str):
-    closingCount = 0
-    copy = True
-    with open(newFile, 'w+') as f1:
+def shellSource(file, new_file: str):
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                Templine = line.replace(" ","")
-                if Templine[0] != "#":            # Syntax for single line comment
-                    f1.write(line)
+            for line in f:
+                content = line
+                if '#' in line:
+                    content = line[:line.find('#')].rstrip() + '\n'
+                if content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/swift.py
+++ b/nirjas/languages/swift.py
@@ -56,29 +56,35 @@ def swiftExtractor(file):
     return output
 
 
-def swiftSource(file, newFile: str):
-    closingCount = 0
+def swiftSource(file, new_file: str):
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                if line.strip() == '/*':
-                    closingCount+=1
+            for line in f:
+                content = ""
+                found = False
+                if '/*' in line:
+                    pos = line.find('/*')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if line.strip() == '*/':
-                    closingCount+=1
-                    copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if copy:
-                    if line.strip() != '/*' and line.strip() != '*/':
-                        Templine = line.replace(" ","")
-                        if Templine[0:2] != "//":            # Syntax for single line comment
-                            f1.write(line)
+                    found = True
+                if '*/' in line:
+                    content = content + line[line.rfind('*/') + 2:]
+                    line = content
+                    copy = True
+                    found = True
+                if '//' in line:
+                    if line[line.find('//') - 1] != ':':
+                        line = line[:line.find('//')].rstrip() + '\n'
+                    elif line[line.rfind('//') - 1] != ':':
+                        line = line[:line.rfind('//')].rstrip() + '\n'
+                    content = line
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/languages/swift.py
+++ b/nirjas/languages/swift.py
@@ -21,43 +21,37 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
 
 
 def swiftExtractor(file):
     result = CommentSyntax()
-    result1 = result.doubleSlash(file)
-    result2 = result.slashStar(file)
-    result4 = contSingleLines(result1)
+    single_line_comment = result.doubleSlash(file)
+    multiline_comment = result.slashStar(file)
+    cont_single_line_comment = contSingleLines(single_line_comment)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "Swift",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3]+result2[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "cont_single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'Swift'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3] + multiline_comment[3]
+    output.blank_lines = single_line_comment[2]
 
-    if result4:
-        result1 = result4[0]
+    if cont_single_line_comment:
+        single_line_comment = cont_single_line_comment[0]
 
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result4:
-        for idx,i in enumerate(result4[1]):
-            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
+    for idx, i in enumerate(cont_single_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_single_line_comment[1][idx], cont_single_line_comment[2][idx],
+            cont_single_line_comment[3][idx]))
 
-    if result2:
-        for idx,i in enumerate(result2[0]):
-            output['multi_line_comment'].append({"start_line": result2[0][idx], "end_line": result2[1][idx], "comment": result2[2][idx]})
-        
+    for idx, i in enumerate(multiline_comment[0]):
+        output.multi_line_comment.append(MultiLine(multiline_comment[0][idx],
+                                                   multiline_comment[1][idx],
+                                                   multiline_comment[2][idx]))
 
     return output
 

--- a/nirjas/languages/tests/test_c.py
+++ b/nirjas/languages/tests/test_c.py
@@ -1,44 +1,43 @@
 import unittest
 import os
 from nirjas.languages import c
-from nirjas.binder import readSingleLine,readMultiLineDiff,contSingleLines
+from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class CTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.c")
 
     def test_output(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         sign = '//'
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
-        comment_single = c.readSingleLine(self.testfile,regex,sign)
-        comment_multiline = c.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        self.syntax_end = '*/'
+        comment_single = c.readSingleLine(self.testfile, regex, sign)
+        comment_multiline = c.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSinglelines = c.contSingleLines(comment_single)
         self.assertTrue(comment_single)
         self.assertTrue(comment_multiline)
         self.assertTrue(comment_contSinglelines)
 
-
     def test_outputFormat(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
         self.syntax_end = "*/"
         sign = '//'
-        expected = c.cExtractor(self.testfile)
-        comment_single = readSingleLine(self.testfile,regex,sign)
-        comment_multiline = readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        expected = c.cExtractor(self.testfile).get_dict()
+        comment_single = readSingleLine(self.testfile, regex, sign)
+        comment_multiline = readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSinglelines = contSingleLines(comment_single)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "C",
         "total_lines": comment_single[1],
-        "total_lines_of_comments": comment_single[3]+comment_multiline[3],
+        "total_lines_of_comments": comment_single[3] + comment_multiline[3],
         "blank_lines": comment_single[2],
-        "sloc": comment_single[1]-(comment_single[3]+comment_multiline[3]+comment_single[2])
-        }],
+        "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2])
+        },
         "single_line_comment": [],
         "cont_single_line_comment": [],
         "multi_line_comment": []
@@ -49,23 +48,23 @@ class CTest(unittest.TestCase):
 
         if comment_single:
             for i in comment_single[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
         if comment_contSinglelines:
-            for idx,i in enumerate(comment_contSinglelines[1]):
+            for idx, i in enumerate(comment_contSinglelines[1]):
                 output['cont_single_line_comment'].append({"start_line": comment_contSinglelines[1][idx], "end_line": comment_contSinglelines[2][idx], "comment": comment_contSinglelines[3][idx]})
 
         if comment_multiline:
             try:
-                for idx,i in enumerate(comment_multiline[0]):
+                for idx, i in enumerate(comment_multiline[0]):
                     output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
             except:
                 pass
-        self.assertEqual(output,expected)  
+        self.assertEqual(output, expected)
 
     def test_Source(self):
         name = "source.txt"
-        newfile = c.cSource(self.testfile,name)
+        newfile = c.cSource(self.testfile, name)
 
         self.assertTrue(newfile)
-        
+

--- a/nirjas/languages/tests/test_c_sharp.py
+++ b/nirjas/languages/tests/test_c_sharp.py
@@ -1,46 +1,44 @@
 import unittest
 import os
 from nirjas.languages import c_sharp
-from nirjas.binder import readSingleLine,readMultiLineDiff,contSingleLines
+from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class CSharpTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.cs")
 
     def test_output(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '//'
-        comment_single = c_sharp.readSingleLine(self.testfile,regex,sign)
-        comment_multiline = c_sharp.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        comment_single = c_sharp.readSingleLine(self.testfile, regex, sign)
+        comment_multiline = c_sharp.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = c_sharp.contSingleLines(comment_single)
 
         self.assertTrue(comment_single)
         self.assertTrue(comment_multiline)
         self.assertTrue(comment_contSingleline)
 
-
-
     def test_outputFormat(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '//'
-        expected = c_sharp.c_sharpExtractor(self.testfile)
-        comment_single = readSingleLine(self.testfile,regex,sign)
-        comment_multiline = readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        expected = c_sharp.c_sharpExtractor(self.testfile).get_dict()
+        comment_single = readSingleLine(self.testfile, regex, sign)
+        comment_multiline = readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = contSingleLines(comment_single)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "C#",
         "total_lines": comment_single[1],
-        "total_lines_of_comments": comment_single[3]+comment_multiline[3],
+        "total_lines_of_comments": comment_single[3] + comment_multiline[3],
         "blank_lines": comment_single[2],
-        "sloc": comment_single[1]-(comment_single[3]+comment_multiline[3]+comment_single[2])
-        }],
+        "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2])
+        },
         "single_line_comment": [],
         "cont_single_line_comment": [],
         "multi_line_comment": []
@@ -51,20 +49,20 @@ class CSharpTest(unittest.TestCase):
 
         if comment_single:
             for i in comment_single[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
         if comment_contSingleline:
-            for idx,i in enumerate(comment_contSingleline[1]):
+            for idx, i in enumerate(comment_contSingleline[1]):
                 output['cont_single_line_comment'].append({"start_line": comment_contSingleline[1][idx], "end_line": comment_contSingleline[2][idx], "comment": comment_contSingleline[3][idx]})
 
         if comment_multiline:
-            for idx,i in enumerate(comment_multiline[0]):
+            for idx, i in enumerate(comment_multiline[0]):
                 output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
-        
-        self.assertEqual(output,expected) 
+
+        self.assertEqual(output, expected)
 
     def test_Source(self):
         name = "source.txt"
-        newfile = c_sharp.c_sharpSource(self.testfile,name)
+        newfile = c_sharp.c_sharpSource(self.testfile, name)
 
         self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_cpp.py
+++ b/nirjas/languages/tests/test_cpp.py
@@ -1,44 +1,43 @@
 import unittest
 import os
 from nirjas.languages import cpp
-from nirjas.binder import readSingleLine,readMultiLineDiff,contSingleLines
+from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
+
 
 class CPPTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.cpp")
 
     def test_output(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '//'
-        comment_single = cpp.readSingleLine(self.testfile,regex,sign)
-        comment_multiline = cpp.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        comment_single = cpp.readSingleLine(self.testfile, regex, sign)
+        comment_multiline = cpp.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = cpp.contSingleLines(comment_single)
         self.assertTrue(comment_single)
         self.assertTrue(comment_multiline)
         self.assertTrue(comment_contSingleline)
 
-
-
     def test_outputFormat(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '//'
-        expected = cpp.cppExtractor(self.testfile)
-        comment_single = readSingleLine(self.testfile,regex,sign)
-        comment_multiline = readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        expected = cpp.cppExtractor(self.testfile).get_dict()
+        comment_single = readSingleLine(self.testfile, regex, sign)
+        comment_multiline = readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = contSingleLines(comment_single)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "C++",
         "total_lines": comment_single[1],
-        "total_lines_of_comments": comment_single[3]+comment_multiline[3],
+        "total_lines_of_comments": comment_single[3] + comment_multiline[3],
         "blank_lines": comment_single[2],
-        "sloc": comment_single[1]-(comment_single[3]+comment_multiline[3]+comment_single[2])
-        }],
+        "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2])
+        },
         "single_line_comment": [],
         "cont_single_line_comment": [],
         "multi_line_comment": []
@@ -49,23 +48,23 @@ class CPPTest(unittest.TestCase):
 
         if comment_single:
             for i in comment_single[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
         if comment_contSingleline:
-            for idx,i in enumerate(comment_contSingleline[1]):
+            for idx, i in enumerate(comment_contSingleline[1]):
                 output['cont_single_line_comment'].append({"start_line": comment_contSingleline[1][idx], "end_line": comment_contSingleline[2][idx], "comment": comment_contSingleline[3][idx]})
 
         if comment_multiline:
             try:
-                for idx,i in enumerate(comment_multiline[0]):
+                for idx, i in enumerate(comment_multiline[0]):
                     output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
             except:
                 pass
 
-        self.assertEqual(output,expected)  
-    
+        self.assertEqual(output, expected)
+
     def test_Source(self):
         name = "source.txt"
-        newfile = cpp.cppSource(self.testfile,name)
+        newfile = cpp.cppSource(self.testfile, name)
 
         self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_css.py
+++ b/nirjas/languages/tests/test_css.py
@@ -9,42 +9,41 @@ class CssTest(unittest.TestCase):
 
     def test_output(self):
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
-        comment_multiline = css.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        self.syntax_end = '*/'
+        comment_multiline = css.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
 
         self.assertTrue(comment_multiline)
 
-
-
     def test_outputFormat(self):
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
-        expected = css.cssExtractor(self.testfile)
-        comment_multiline = readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        self.syntax_end = '*/'
+        expected = css.cssExtractor(self.testfile).get_dict()
+        comment_multiline = readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "CSS",
         "total_lines": comment_multiline[4],
         "total_lines_of_comments": comment_multiline[3],
         "blank_lines": comment_multiline[5],
-        "sloc": comment_multiline[4]-(comment_multiline[3]+comment_multiline[5])
-        }],
+        "sloc": comment_multiline[4] - (comment_multiline[3] + comment_multiline[5])
+        },
         "single_line_comment": [],
+        "cont_single_line_comment": [],
         "multi_line_comment": []
         }
         if comment_multiline:
             try:
-                for idx,i in enumerate(comment_multiline[0]):
+                for idx, i in enumerate(comment_multiline[0]):
                     output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
             except:
                 pass
 
-        self.assertEqual(output,expected)  
-    
+        self.assertEqual(output, expected)
+
     def test_Source(self):
         name = "source.txt"
-        newfile = css.cssSource(self.testfile,name)
+        newfile = css.cssSource(self.testfile, name)
 
         self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_dart.py
+++ b/nirjas/languages/tests/test_dart.py
@@ -21,21 +21,22 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 import unittest
 import os
 from nirjas.languages import dart
-from nirjas.binder import readSingleLine,readMultiLineDiff
+from nirjas.binder import readSingleLine, readMultiLineDiff
+
 
 class DartTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.dart")
 
     def test_output(self):
-        regex1 = r'''((?<!\/)\/\/(?!\/)\s*[\w #\.()@+-_*\d]*)'''
-        regex2 = r'''(\/\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex1 = r'''(?<!\/)\/\/(?!\/)\s*(.*)'''
+        regex2 = r'''\/\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign1 = '//'
         sign2 = '///'
-        comment_single_doubleSlash = dart.readSingleLine(self.testfile,regex1,sign1)
-        comment_single_tripleSlash = dart.readSingleLine(self.testfile,regex2,sign2)
-        comment_multiline = dart.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        comment_single_doubleSlash = dart.readSingleLine(self.testfile, regex1, sign1)
+        comment_single_tripleSlash = dart.readSingleLine(self.testfile, regex2, sign2)
+        comment_multiline = dart.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline1 = dart.contSingleLines(comment_single_doubleSlash)
         comment_contSingleline2 = dart.contSingleLines(comment_single_tripleSlash)
         self.assertTrue(comment_single_doubleSlash)
@@ -44,30 +45,29 @@ class DartTest(unittest.TestCase):
         self.assertTrue(comment_contSingleline1)
         self.assertTrue(comment_contSingleline2)
 
-
     def test_outputFormat(self):
-        regex1 = r'''((?<!\/)\/\/(?!\/)\s*[\w #\.()@+-_*\d]*)'''
-        regex2 = r'''(\/\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex1 = r'''(?<!\/)\/\/(?!\/)\s*(.*)'''
+        regex2 = r'''\/\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign1 = '//'
         sign2 = '///'
-        expected = dart.dartExtractor(self.testfile)
-        comment_single_doubleSlash = dart.readSingleLine(self.testfile,regex1,sign1)
-        comment_single_tripleSlash = dart.readSingleLine(self.testfile,regex2,sign2)
-        comment_multiline = dart.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        expected = dart.dartExtractor(self.testfile).get_dict()
+        comment_single_doubleSlash = dart.readSingleLine(self.testfile, regex1, sign1)
+        comment_single_tripleSlash = dart.readSingleLine(self.testfile, regex2, sign2)
+        comment_multiline = dart.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline1 = dart.contSingleLines(comment_single_doubleSlash)
         comment_contSingleline2 = dart.contSingleLines(comment_single_tripleSlash)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "Dart",
         "total_lines": comment_single_doubleSlash[1],
-        "total_lines_of_comments": comment_single_doubleSlash[3]+comment_single_tripleSlash[3]+comment_multiline[3],
+        "total_lines_of_comments": comment_single_doubleSlash[3] + comment_single_tripleSlash[3] + comment_multiline[3],
         "blank_lines": comment_single_doubleSlash[2],
-        "sloc": comment_single_doubleSlash[1]-(comment_single_doubleSlash[3]+comment_single_tripleSlash[3]+comment_multiline[3]+comment_single_doubleSlash[2])
-        }],
+        "sloc": comment_single_doubleSlash[1] - (comment_single_doubleSlash[3] + comment_single_tripleSlash[3] + comment_multiline[3] + comment_single_doubleSlash[2])
+        },
         "single_line_comment": [],
         "cont_single_line_comment": [],
         "multi_line_comment": []
@@ -81,31 +81,31 @@ class DartTest(unittest.TestCase):
 
         if comment_single_doubleSlash:
             for i in comment_single_doubleSlash[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
         if comment_single_tripleSlash:
             for i in comment_single_tripleSlash[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
         if comment_contSingleline1:
-            for idx,i in enumerate(comment_contSingleline1[1]):
+            for idx, i in enumerate(comment_contSingleline1[1]):
                 output['cont_single_line_comment'].append({"start_line": comment_contSingleline1[1][idx], "end_line": comment_contSingleline1[2][idx], "comment": comment_contSingleline1[3][idx]})
 
         if comment_contSingleline2:
-            for idx,i in enumerate(comment_contSingleline2[1]):
+            for idx, i in enumerate(comment_contSingleline2[1]):
                 output['cont_single_line_comment'].append({"start_line": comment_contSingleline2[1][idx], "end_line": comment_contSingleline2[2][idx], "comment": comment_contSingleline2[3][idx]})
 
         if comment_multiline:
             try:
-                for idx,i in enumerate(comment_multiline[0]):
+                for idx, i in enumerate(comment_multiline[0]):
                     output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
             except:
                 pass
 
-        self.assertEqual(output,expected)
+        self.assertEqual(output, expected)
 
     def test_Source(self):
         name = "source.txt"
-        newfile = dart.dartSource(self.testfile,name)
+        newfile = dart.dartSource(self.testfile, name)
 
         self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_go.py
+++ b/nirjas/languages/tests/test_go.py
@@ -1,45 +1,43 @@
 import unittest
 import os
 from nirjas.languages import go
-from nirjas.binder import readSingleLine,readMultiLineDiff,contSingleLines
+from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class GoTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.cs")
 
     def test_output(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '//'
-        comment_single = go.readSingleLine(self.testfile,regex,sign)
-        comment_multiline = go.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        comment_single = go.readSingleLine(self.testfile, regex, sign)
+        comment_multiline = go.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = go.contSingleLines(comment_single)
         self.assertTrue(comment_single)
         self.assertTrue(comment_multiline)
         self.assertTrue(comment_contSingleline)
 
-
-
     def test_outputFormat(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '//'
-        expected = go.goExtractor(self.testfile)
-        comment_single = readSingleLine(self.testfile,regex,sign)
-        comment_multiline = readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        expected = go.goExtractor(self.testfile).get_dict()
+        comment_single = readSingleLine(self.testfile, regex, sign)
+        comment_multiline = readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = contSingleLines(comment_single)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "Go",
         "total_lines": comment_single[1],
-        "total_lines_of_comments": comment_single[3]+comment_multiline[3],
+        "total_lines_of_comments": comment_single[3] + comment_multiline[3],
         "blank_lines": comment_single[2],
-        "sloc": comment_single[1]-(comment_single[3]+comment_multiline[3]+comment_single[2])
-        }],
+        "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2])
+        },
         "single_line_comment": [],
         "cont_single_line_comment": [],
         "multi_line_comment": []
@@ -50,20 +48,20 @@ class GoTest(unittest.TestCase):
 
         if comment_single:
             for i in comment_single[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
         if comment_contSingleline:
-            for idx,i in enumerate(comment_contSingleline[1]):
+            for idx, i in enumerate(comment_contSingleline[1]):
                 output['cont_single_line_comment'].append({"start_line": comment_contSingleline[1][idx], "end_line": comment_contSingleline[2][idx], "comment": comment_contSingleline[3][idx]})
 
         if comment_multiline:
-            for idx,i in enumerate(comment_multiline[0]):
+            for idx, i in enumerate(comment_multiline[0]):
                 output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
 
-        self.assertEqual(output,expected)
+        self.assertEqual(output, expected)
 
     def test_Source(self):
         name = "source.txt"
-        newfile = go.goSource(self.testfile,name)
+        newfile = go.goSource(self.testfile, name)
 
         self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_haskell.py
+++ b/nirjas/languages/tests/test_haskell.py
@@ -1,45 +1,43 @@
 import unittest
 import os
 from nirjas.languages import haskell
-from nirjas.binder import readSingleLine,readMultiLineDiff,contSingleLines
+from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class HaskellTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.hs")
 
     def test_output(self):
-        regex = r'''(\-\-\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''\-\-\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '--'
-        comment_single = haskell.readSingleLine(self.testfile,regex,sign)
-        comment_multiline = haskell.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        comment_single = haskell.readSingleLine(self.testfile, regex, sign)
+        comment_multiline = haskell.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = haskell.contSingleLines(comment_single)
         self.assertTrue(comment_single)
         self.assertTrue(comment_multiline)
         self.assertTrue(comment_contSingleline)
 
-
-
     def test_outputFormat(self):
-        regex = r'''(\-\-\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''\-\-\s*(.*)'''
         self.syntax_start = "{-"
         self.syntax_end = "-}"
         sign = '--'
-        expected = haskell.haskellExtractor(self.testfile)
-        comment_single = readSingleLine(self.testfile,regex,sign)
-        comment_multiline = readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        expected = haskell.haskellExtractor(self.testfile).get_dict()
+        comment_single = readSingleLine(self.testfile, regex, sign)
+        comment_multiline = readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = contSingleLines(comment_single)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "Haskell",
         "total_lines": comment_single[1],
-        "total_lines_of_comments": comment_single[3]+comment_multiline[3],
+        "total_lines_of_comments": comment_single[3] + comment_multiline[3],
         "blank_lines": comment_single[2],
-        "sloc": comment_single[1]-(comment_single[3]+comment_multiline[3]+comment_single[2])
-        }],
+        "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2])
+        },
         "single_line_comment": [],
         "cont_single_line_comment": [],
         "multi_line_comment": []
@@ -50,21 +48,20 @@ class HaskellTest(unittest.TestCase):
 
         if comment_single:
             for i in comment_single[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
         if comment_contSingleline:
-            for idx,i in enumerate(comment_contSingleline[1]):
+            for idx, i in enumerate(comment_contSingleline[1]):
                 output['cont_single_line_comment'].append({"start_line": comment_contSingleline[1][idx], "end_line": comment_contSingleline[2][idx], "comment": comment_contSingleline[3][idx]})
 
         if comment_multiline:
-            for idx,i in enumerate(comment_multiline[0]):
+            for idx, i in enumerate(comment_multiline[0]):
                 output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
-    
-        self.assertEqual(output,expected)
+
+        self.assertEqual(output, expected)
 
     def test_Source(self):
         name = "source.txt"
-        newfile = haskell.haskellSource(self.testfile,name)
+        newfile = haskell.haskellSource(self.testfile, name)
 
-        self.assertTrue(newfile) 
-        
+        self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_html.py
+++ b/nirjas/languages/tests/test_html.py
@@ -11,57 +11,54 @@ class HTMLTest(unittest.TestCase):
         self.start_exclamation = "<!--"
         self.end_exclamation = "-->"
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
-        comment_single = html.readMultiLineDiff(self.testfile,self.start_exclamation,self.end_exclamation)
-        comment_multiline = html.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        self.syntax_end = '*/'
+        comment_single = html.readMultiLineDiff(self.testfile, self.start_exclamation, self.end_exclamation)
+        comment_multiline = html.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
 
         self.assertTrue(comment_single)
         self.assertTrue(comment_multiline)
-
-
 
     def test_outputFormat(self):
         self.start_exclamation = "<!--"
         self.end_exclamation = "-->"
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
-        expected = html.htmlExtractor(self.testfile)
-        comment_single = readMultiLineDiff(self.testfile,self.start_exclamation,self.end_exclamation)
-        comment_multiline = readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        self.syntax_end = '*/'
+        expected = html.htmlExtractor(self.testfile).get_dict()
+        comment_single = readMultiLineDiff(self.testfile, self.start_exclamation, self.end_exclamation)
+        comment_multiline = readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "HTML",
         "total_lines": comment_single[4],
-        "total_lines_of_comments": comment_single[3]+comment_multiline[3],
+        "total_lines_of_comments": comment_single[3] + comment_multiline[3],
         "blank_lines": comment_single[5],
-        "sloc": comment_single[4]-(comment_single[3]+comment_multiline[3]+comment_single[5])
-        }],
+        "sloc": comment_single[4] - (comment_single[3] + comment_multiline[3] + comment_single[5])
+        },
         "single_line_comment": [],
         "cont_single_line_comment": [],
         "multi_line_comment": []
         }
 
-
         if comment_single:
             try:
-                for idx,i in enumerate(comment_single[0]):
+                for idx, i in enumerate(comment_single[0]):
                     output['multi_line_comment'].append({"start_line": comment_single[0][idx], "end_line": comment_single[1][idx], "comment": comment_single[2][idx]})
             except:
                 pass
-        
+
         if comment_multiline:
             try:
-                for idx,i in enumerate(comment_multiline[0]):
+                for idx, i in enumerate(comment_multiline[0]):
                     output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
             except:
                 pass
 
-        self.assertEqual(output,expected)  
-    
+        self.assertEqual(output, expected)
+
     def test_Source(self):
         name = "source.txt"
-        newfile = html.htmlSource(self.testfile,name)
+        newfile = html.htmlSource(self.testfile, name)
 
         self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_java.py
+++ b/nirjas/languages/tests/test_java.py
@@ -1,44 +1,43 @@
 import unittest
 import os
 from nirjas.languages import java
-from nirjas.binder import readSingleLine,readMultiLineDiff,contSingleLines
+from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
+
 
 class JavaTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.java")
 
     def test_output(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '//'
-        comment_single = java.readSingleLine(self.testfile,regex,sign)
-        comment_multiline = java.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        comment_single = java.readSingleLine(self.testfile, regex, sign)
+        comment_multiline = java.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = java.contSingleLines(comment_single)
         self.assertTrue(comment_single)
         self.assertTrue(comment_multiline)
         self.assertTrue(comment_contSingleline)
 
-
-
     def test_outputFormat(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '//'
-        expected = java.javaExtractor(self.testfile)
-        comment_single = readSingleLine(self.testfile,regex,sign)
-        comment_multiline = readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        expected = java.javaExtractor(self.testfile).get_dict()
+        comment_single = readSingleLine(self.testfile, regex, sign)
+        comment_multiline = readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = contSingleLines(comment_single)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "Java",
         "total_lines": comment_single[1],
-        "total_lines_of_comments": comment_single[3]+comment_multiline[3],
+        "total_lines_of_comments": comment_single[3] + comment_multiline[3],
         "blank_lines": comment_single[2],
-        "sloc": comment_single[1]-(comment_single[3]+comment_multiline[3]+comment_single[2])
-        }],
+        "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2])
+        },
         "single_line_comment": [],
         "cont_single_line_comment": [],
         "multi_line_comment": []
@@ -49,20 +48,20 @@ class JavaTest(unittest.TestCase):
 
         if comment_single:
             for i in comment_single[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
         if comment_contSingleline:
-            for idx,i in enumerate(comment_contSingleline[1]):
+            for idx, i in enumerate(comment_contSingleline[1]):
                 output['cont_single_line_comment'].append({"start_line": comment_contSingleline[1][idx], "end_line": comment_contSingleline[2][idx], "comment": comment_contSingleline[3][idx]})
 
         if comment_multiline:
-            for idx,i in enumerate(comment_multiline[0]):
+            for idx, i in enumerate(comment_multiline[0]):
                 output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
 
-        self.assertEqual(output,expected) 
+        self.assertEqual(output, expected)
 
     def test_Source(self):
         name = "source.txt"
-        newfile = java.javaSource(self.testfile,name)
+        newfile = java.javaSource(self.testfile, name)
 
         self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_javascript.py
+++ b/nirjas/languages/tests/test_javascript.py
@@ -1,43 +1,43 @@
 import unittest
 import os
 from nirjas.languages import javascript
-from nirjas.binder import readSingleLine,readMultiLineDiff
+from nirjas.binder import readSingleLine, readMultiLineDiff
+
 
 class JSTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.js")
 
     def test_output(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '//'
-        comment_single = javascript.readSingleLine(self.testfile,regex,sign)
-        comment_multiline = javascript.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        comment_single = javascript.readSingleLine(self.testfile, regex, sign)
+        comment_multiline = javascript.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = javascript.contSingleLines(comment_single)
         self.assertTrue(comment_single)
         self.assertTrue(comment_multiline)
         self.assertTrue(comment_contSingleline)
 
-
     def test_outputFormat(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '//'
-        expected = javascript.javascriptExtractor(self.testfile)
-        comment_single = readSingleLine(self.testfile,regex,sign)
-        comment_multiline = readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        expected = javascript.javascriptExtractor(self.testfile).get_dict()
+        comment_single = readSingleLine(self.testfile, regex, sign)
+        comment_multiline = readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = javascript.contSingleLines(comment_single)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "JavaScript",
         "total_lines": comment_single[1],
-        "total_lines_of_comments": comment_single[3]+comment_multiline[3],
+        "total_lines_of_comments": comment_single[3] + comment_multiline[3],
         "blank_lines": comment_single[2],
-        "sloc": comment_single[1]-(comment_single[3]+comment_multiline[3]+comment_single[2])
-        }],
+        "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2])
+        },
         "single_line_comment": [],
         "cont_single_line_comment": [],
         "multi_line_comment": []
@@ -48,23 +48,23 @@ class JSTest(unittest.TestCase):
 
         if comment_single:
             for i in comment_single[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
         if comment_contSingleline:
-            for idx,i in enumerate(comment_contSingleline[1]):
+            for idx, i in enumerate(comment_contSingleline[1]):
                 output['cont_single_line_comment'].append({"start_line": comment_contSingleline[1][idx], "end_line": comment_contSingleline[2][idx], "comment": comment_contSingleline[3][idx]})
 
         if comment_multiline:
             try:
-                for idx,i in enumerate(comment_multiline[0]):
+                for idx, i in enumerate(comment_multiline[0]):
                     output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
             except:
                 pass
 
-        self.assertEqual(output,expected)
+        self.assertEqual(output, expected)
 
     def test_Source(self):
         name = "source.txt"
-        newfile = javascript.javascriptSource(self.testfile,name)
+        newfile = javascript.javascriptSource(self.testfile, name)
 
-        self.assertTrue(newfile)  
+        self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_kotlin.py
+++ b/nirjas/languages/tests/test_kotlin.py
@@ -1,45 +1,43 @@
 import unittest
 import os
 from nirjas.languages import kotlin
-from nirjas.binder import readSingleLine,readMultiLineDiff,contSingleLines
+from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class KotlinTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.kts")
 
     def test_output(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '//'
-        comment_single = kotlin.readSingleLine(self.testfile,regex,sign)
-        comment_multiline = kotlin.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        comment_single = kotlin.readSingleLine(self.testfile, regex, sign)
+        comment_multiline = kotlin.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = kotlin.contSingleLines(comment_single)
         self.assertTrue(comment_single)
         self.assertTrue(comment_multiline)
         self.assertTrue(comment_contSingleline)
 
-
-
     def test_outputFormat(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '//'
-        expected = kotlin.kotlinExtractor(self.testfile)
-        comment_single = readSingleLine(self.testfile,regex,sign)
-        comment_multiline = readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        expected = kotlin.kotlinExtractor(self.testfile).get_dict()
+        comment_single = readSingleLine(self.testfile, regex, sign)
+        comment_multiline = readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = contSingleLines(comment_single)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "Kotlin",
         "total_lines": comment_single[1],
-        "total_lines_of_comments": comment_single[3]+comment_multiline[3],
+        "total_lines_of_comments": comment_single[3] + comment_multiline[3],
         "blank_lines": comment_single[2],
-        "sloc": comment_single[1]-(comment_single[3]+comment_multiline[3]+comment_single[2])
-        }],
+        "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2])
+        },
         "single_line_comment": [],
         "cont_single_line_comment": [],
         "multi_line_comment": []
@@ -50,20 +48,20 @@ class KotlinTest(unittest.TestCase):
 
         if comment_single:
             for i in comment_single[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
         if comment_contSingleline:
-            for idx,i in enumerate(comment_contSingleline[1]):
+            for idx, i in enumerate(comment_contSingleline[1]):
                 output['cont_single_line_comment'].append({"start_line": comment_contSingleline[1][idx], "end_line": comment_contSingleline[2][idx], "comment": comment_contSingleline[3][idx]})
 
         if comment_multiline:
-            for idx,i in enumerate(comment_multiline[0]):
+            for idx, i in enumerate(comment_multiline[0]):
                 output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
 
-        self.assertEqual(output,expected)
+        self.assertEqual(output, expected)
 
     def test_Source(self):
         name = "source.txt"
-        newfile = kotlin.kotlinSource(self.testfile,name)
+        newfile = kotlin.kotlinSource(self.testfile, name)
 
         self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_matlab.py
+++ b/nirjas/languages/tests/test_matlab.py
@@ -1,45 +1,43 @@
 import unittest
 import os
 from nirjas.languages import matlab
-from nirjas.binder import readSingleLine,readMultiLineDiff,contSingleLines
+from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class matlabTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.m")
 
     def test_output(self):
-        regex = r'''(\%\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''\%\s*(.*)'''
         self.syntax_start = "%{"
         self.syntax_end = "%}"
         sign = '%'
-        comment_single = matlab.readSingleLine(self.testfile,regex,sign)
-        comment_multiline = matlab.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        comment_single = matlab.readSingleLine(self.testfile, regex, sign)
+        comment_multiline = matlab.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = matlab.contSingleLines(comment_single)
         self.assertTrue(comment_single)
         self.assertTrue(comment_multiline)
         self.assertTrue(comment_contSingleline)
 
-
-
     def test_outputFormat(self):
-        regex = r'''(\%\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''\%\s*(.*)'''
         self.syntax_start = "%{"
         self.syntax_end = "%}"
         sign = '%'
-        expected = matlab.matlabExtractor(self.testfile)
-        comment_single = readSingleLine(self.testfile,regex,sign)
-        comment_multiline = readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        expected = matlab.matlabExtractor(self.testfile).get_dict()
+        comment_single = readSingleLine(self.testfile, regex, sign)
+        comment_multiline = readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = contSingleLines(comment_single)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "MATLAB",
         "total_lines": comment_single[1],
-        "total_lines_of_comments": comment_single[3]+comment_multiline[3],
+        "total_lines_of_comments": comment_single[3] + comment_multiline[3],
         "blank_lines": comment_single[2],
-        "sloc": comment_single[1]-(comment_single[3]+comment_multiline[3]+comment_single[2])
-        }],
+        "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2])
+        },
         "single_line_comment": [],
         "cont_single_line_comment": [],
         "multi_line_comment": []
@@ -50,20 +48,20 @@ class matlabTest(unittest.TestCase):
 
         if comment_single:
             for i in comment_single[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
         if comment_contSingleline:
-            for idx,i in enumerate(comment_contSingleline[1]):
+            for idx, i in enumerate(comment_contSingleline[1]):
                 output['cont_single_line_comment'].append({"start_line": comment_contSingleline[1][idx], "end_line": comment_contSingleline[2][idx], "comment": comment_contSingleline[3][idx]})
 
         if comment_multiline:
-            for idx,i in enumerate(comment_multiline[0]):
+            for idx, i in enumerate(comment_multiline[0]):
                 output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
 
-        self.assertEqual(output,expected)
+        self.assertEqual(output, expected)
 
     def test_Source(self):
         name = "source.txt"
-        newfile = matlab.matlabSource(self.testfile,name)
+        newfile = matlab.matlabSource(self.testfile, name)
 
         self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_perl.py
+++ b/nirjas/languages/tests/test_perl.py
@@ -1,45 +1,43 @@
 import unittest
 import os
 from nirjas.languages import perl
-from nirjas.binder import readSingleLine,readMultiLineDiff,contSingleLines
+from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class perlTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.pl")
 
     def test_output(self):
-        regex = r'''(#+\s*[\!\w #\.()@+-_*\d]*)'''
+        regex = r'''#+\s*(.*)'''
         self.syntax_start = "=begin"
         self.syntax_end = "=cut"
         sign = '#'
-        comment_single = perl.readSingleLine(self.testfile,regex,sign)
-        comment_multiline = perl.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        comment_single = perl.readSingleLine(self.testfile, regex, sign)
+        comment_multiline = perl.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = perl.contSingleLines(comment_single)
         self.assertTrue(comment_single)
         self.assertTrue(comment_multiline)
         self.assertTrue(comment_contSingleline)
 
-
-
     def test_outputFormat(self):
-        regex = r'''(#+\s*[\!\w #\.()@+-_*\d]*)'''
+        regex = r'''#+\s*(.*)'''
         self.syntax_start = "=begin"
         self.syntax_end = "=cut"
         sign = '#'
-        expected = perl.perlExtractor(self.testfile)
-        comment_single = readSingleLine(self.testfile,regex,sign)
-        comment_multiline = readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        expected = perl.perlExtractor(self.testfile).get_dict()
+        comment_single = readSingleLine(self.testfile, regex, sign)
+        comment_multiline = readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = contSingleLines(comment_single)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "Perl",
         "total_lines": comment_single[1],
-        "total_lines_of_comments": comment_single[3]+comment_multiline[3],
+        "total_lines_of_comments": comment_single[3] + comment_multiline[3],
         "blank_lines": comment_single[2],
-        "sloc": comment_single[1]-(comment_single[3]+comment_multiline[3]+comment_single[2])
-        }],
+        "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2])
+        },
         "single_line_comment": [],
         "cont_single_line_comment": [],
         "multi_line_comment": []
@@ -50,20 +48,20 @@ class perlTest(unittest.TestCase):
 
         if comment_single:
             for i in comment_single[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
         if comment_contSingleline:
-            for idx,i in enumerate(comment_contSingleline[1]):
+            for idx, i in enumerate(comment_contSingleline[1]):
                 output['cont_single_line_comment'].append({"start_line": comment_contSingleline[1][idx], "end_line": comment_contSingleline[2][idx], "comment": comment_contSingleline[3][idx]})
 
         if comment_multiline:
-            for idx,i in enumerate(comment_multiline[0]):
+            for idx, i in enumerate(comment_multiline[0]):
                 output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
 
-        self.assertEqual(output,expected)
+        self.assertEqual(output, expected)
 
     def test_Source(self):
         name = "source.txt"
-        newfile = perl.perlSource(self.testfile,name)
+        newfile = perl.perlSource(self.testfile, name)
 
         self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_php.py
+++ b/nirjas/languages/tests/test_php.py
@@ -1,45 +1,43 @@
 import unittest
 import os
 from nirjas.languages import php
-from nirjas.binder import readSingleLine,readMultiLineDiff,contSingleLines
+from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class PHPTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.php")
 
     def test_output(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '//'
-        comment_single = php.readSingleLine(self.testfile,regex,sign)
-        comment_multiline = php.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        comment_single = php.readSingleLine(self.testfile, regex, sign)
+        comment_multiline = php.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = php.contSingleLines(comment_single)
         self.assertTrue(comment_single)
         self.assertTrue(comment_multiline)
         self.assertTrue(comment_contSingleline)
 
-
-
     def test_outputFormat(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '//'
-        expected = php.phpExtractor(self.testfile)
-        comment_single = readSingleLine(self.testfile,regex,sign)
-        comment_multiline = readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        expected = php.phpExtractor(self.testfile).get_dict()
+        comment_single = readSingleLine(self.testfile, regex, sign)
+        comment_multiline = readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = contSingleLines(comment_single)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "PHP",
         "total_lines": comment_single[1],
-        "total_lines_of_comments": comment_single[3]+comment_multiline[3],
+        "total_lines_of_comments": comment_single[3] + comment_multiline[3],
         "blank_lines": comment_single[2],
-        "sloc": comment_single[1]-(comment_single[3]+comment_multiline[3]+comment_single[2])
-        }],
+        "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2])
+        },
         "single_line_comment": [],
         "cont_single_line_comment": [],
         "multi_line_comment": []
@@ -50,20 +48,20 @@ class PHPTest(unittest.TestCase):
 
         if comment_single:
             for i in comment_single[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
         if comment_contSingleline:
-            for idx,i in enumerate(comment_contSingleline[1]):
+            for idx, i in enumerate(comment_contSingleline[1]):
                 output['cont_single_line_comment'].append({"start_line": comment_contSingleline[1][idx], "end_line": comment_contSingleline[2][idx], "comment": comment_contSingleline[3][idx]})
 
         if comment_multiline:
-            for idx,i in enumerate(comment_multiline[0]):
+            for idx, i in enumerate(comment_multiline[0]):
                 output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
 
-        self.assertEqual(output,expected)
+        self.assertEqual(output, expected)
 
     def test_Source(self):
         name = "source.txt"
-        newfile = php.phpSource(self.testfile,name)
+        newfile = php.phpSource(self.testfile, name)
 
         self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_python.py
+++ b/nirjas/languages/tests/test_python.py
@@ -1,83 +1,80 @@
 import unittest
 import os
 from nirjas.languages import python
-from nirjas.binder import readSingleLine,readMultiLineSame,contSingleLines
+from nirjas.binder import readSingleLine, readMultiLineSame, contSingleLines
 
 
 class PythonTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.py")
 
     def test_output(self):
-        regex = r'''(#+\s*[\!\w #\.()@+-_*\d]*)'''
+        regex = r'''#+\s*(.*)'''
         self.syntax_single = "'''"
-        self.syntax_double ='"""'
+        self.syntax_double = '"""'
         sign = '#'
-        comment_multi_single = python.readMultiLineSame(self.testfile,self.syntax_single)
-        comment_single = python.readSingleLine(self.testfile,regex,sign)
-        comment_multi_double = python.readMultiLineSame(self.testfile,self.syntax_double)
+        comment_multi_single = python.readMultiLineSame(self.testfile, self.syntax_single)
+        comment_single = python.readSingleLine(self.testfile, regex, sign)
+        comment_multi_double = python.readMultiLineSame(self.testfile, self.syntax_double)
         comment_contSingleline = python.contSingleLines(comment_single)
         self.assertTrue(comment_single)
         self.assertTrue(comment_multi_single)
         self.assertTrue(comment_multi_double)
         self.assertTrue(comment_contSingleline)
 
-
-
     def test_outputFormat(self):
-        regex = r'''(#+\s*[\!\w #\.()@+-_*\d]*)'''
+        regex = r'''#+\s*(.*)'''
         self.syntax_single = "'''"
-        self.syntax_double ='"""'
+        self.syntax_double = '"""'
         sign = '#'
-        expected = python.pythonExtractor(self.testfile)
-        comment_single = readSingleLine(self.testfile,regex,sign)
-        comment_multi_single = readMultiLineSame(self.testfile,self.syntax_single)
-        comment_multi_double = readMultiLineSame(self.testfile,self.syntax_double)
+        expected = python.pythonExtractor(self.testfile).get_dict()
+        comment_single = readSingleLine(self.testfile, regex, sign)
+        comment_multi_single = readMultiLineSame(self.testfile, self.syntax_single)
+        comment_multi_double = readMultiLineSame(self.testfile, self.syntax_double)
         comment_contSingleline = contSingleLines(comment_single)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "Python",
         "total_lines": comment_single[1],
-        "total_lines_of_comments": comment_single[3]+comment_multi_single[3]+comment_multi_double[3],
+        "total_lines_of_comments": comment_single[3] + comment_multi_single[3] + comment_multi_double[3],
         "blank_lines": comment_single[2],
-        "sloc": comment_single[1]-(comment_single[3]+comment_multi_single[3]+comment_multi_double[3]+comment_single[2])
-        }],
+        "sloc": comment_single[1] - (comment_single[3] + comment_multi_single[3] + comment_multi_double[3] + comment_single[2])
+        },
         "single_line_comment": [],
         "cont_single_line_comment": [],
         "multi_line_comment": []
         }
-
 
         if comment_contSingleline:
             comment_single = comment_contSingleline[0]
 
         if comment_single:
             for i in comment_single[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
         if comment_contSingleline:
-            for idx,i in enumerate(comment_contSingleline[1]):
+            for idx, i in enumerate(comment_contSingleline[1]):
                 output['cont_single_line_comment'].append({"start_line": comment_contSingleline[1][idx], "end_line": comment_contSingleline[2][idx], "comment": comment_contSingleline[3][idx]})
 
         if comment_multi_single:
             try:
-                for idx,i in enumerate(comment_multi_single[0]):
+                for idx, i in enumerate(comment_multi_single[0]):
                     output['multi_line_comment'].append({"start_line": comment_multi_single[0][idx], "end_line": comment_multi_single[1][idx], "comment": comment_multi_single[2][idx]})
             except:
                 pass
-        
+
         if comment_multi_double:
             try:
-                for idx,i in enumerate(comment_multi_double[0]):
+                for idx, i in enumerate(comment_multi_double[0]):
                     output['multi_line_comment'].append({"start_line": comment_multi_double[0][idx], "end_line": comment_multi_double[1][idx], "comment": comment_multi_double[2][idx]})
             except:
                 pass
 
-        self.assertEqual(output,expected)
+        self.assertEqual(output, expected)
 
     def test_Source(self):
         name = "source.txt"
-        newfile = python.pythonSource(self.testfile,name)
+        newfile = python.pythonSource(self.testfile, name)
 
         self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_r.py
+++ b/nirjas/languages/tests/test_r.py
@@ -3,42 +3,42 @@ import os
 from nirjas.languages import r
 from nirjas.binder import readSingleLine
 
+
 class rTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.R")
 
     def test_output(self):
-        regex = r'''(#+\s*[\!\w #\.()@+-_*\d]*)'''
+        regex = r'''#+\s*(.*)'''
         sign = '#'
-        comment_single = r.readSingleLine(self.testfile,regex,sign)
+        comment_single = r.readSingleLine(self.testfile, regex, sign)
         self.assertTrue(comment_single)
 
-
-
     def test_outputFormat(self):
-        regex = r'''(#+\s*[\!\w #\.()@+-_*\d]*)'''
+        regex = r'''#+\s*(.*)'''
         sign = '#'
-        expected = r.rExtractor(self.testfile)
-        comment_single = readSingleLine(self.testfile,regex,sign)
+        expected = r.rExtractor(self.testfile).get_dict()
+        comment_single = readSingleLine(self.testfile, regex, sign)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "R",
         "total_lines": comment_single[1],
         "total_lines_of_comments": comment_single[3],
         "blank_lines": comment_single[2],
-        "sloc": comment_single[1]-(comment_single[3]+comment_single[2])
-        }],
+        "sloc": comment_single[1] - (comment_single[3] + comment_single[2])
+        },
         "single_line_comment": [],
+        "cont_single_line_comment": [],
         "multi_line_comment": []
         }
         if comment_single:
             for i in comment_single[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
-        self.assertEqual(output,expected)
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
+        self.assertEqual(output, expected)
 
     def test_Source(self):
         name = "source.txt"
-        newfile = r.rSource(self.testfile,name)
+        newfile = r.rSource(self.testfile, name)
 
         self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_ruby.py
+++ b/nirjas/languages/tests/test_ruby.py
@@ -1,45 +1,43 @@
 import unittest
 import os
 from nirjas.languages import ruby
-from nirjas.binder import readSingleLine,readMultiLineDiff,contSingleLines
+from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class RubyTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.rb")
 
     def test_output(self):
-        regex = r'''(#+\s*[\!\w #\.()@+-_*\d]*)'''
+        regex = r'''#+\s*(.*)'''
         self.syntax_start = "=begin"
         self.syntax_end = "=end"
         sign = '#'
-        comment_single = ruby.readSingleLine(self.testfile,regex,sign)
-        comment_multiline = ruby.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        comment_single = ruby.readSingleLine(self.testfile, regex, sign)
+        comment_multiline = ruby.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = ruby.contSingleLines(comment_single)
         self.assertTrue(comment_single)
         self.assertTrue(comment_multiline)
         self.assertTrue(comment_contSingleline)
 
-
-
     def test_outputFormat(self):
-        regex = r'''(#+\s*[\!\w #\.()@+-_*\d]*)'''
+        regex = r'''#+\s*(.*)'''
         self.syntax_start = "=begin"
         self.syntax_end = "=cut"
         sign = '#'
-        expected = ruby.rubyExtractor(self.testfile)
-        comment_single = readSingleLine(self.testfile,regex,sign)
-        comment_multiline = readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        expected = ruby.rubyExtractor(self.testfile).get_dict()
+        comment_single = readSingleLine(self.testfile, regex, sign)
+        comment_multiline = readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = contSingleLines(comment_single)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "Ruby",
         "total_lines": comment_single[1],
-        "total_lines_of_comments": comment_single[3]+comment_multiline[3],
+        "total_lines_of_comments": comment_single[3] + comment_multiline[3],
         "blank_lines": comment_single[2],
-        "sloc": comment_single[1]-(comment_single[3]+comment_multiline[3]+comment_single[2])
-        }],
+        "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2])
+        },
         "single_line_comment": [],
         "cont_single_line_comment": [],
         "multi_line_comment": []
@@ -50,20 +48,20 @@ class RubyTest(unittest.TestCase):
 
         if comment_single:
             for i in comment_single[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
         if comment_contSingleline:
-            for idx,i in enumerate(comment_contSingleline[1]):
+            for idx, i in enumerate(comment_contSingleline[1]):
                 output['cont_single_line_comment'].append({"start_line": comment_contSingleline[1][idx], "end_line": comment_contSingleline[2][idx], "comment": comment_contSingleline[3][idx]})
 
         if comment_multiline:
-            for idx,i in enumerate(comment_multiline[0]):
+            for idx, i in enumerate(comment_multiline[0]):
                 output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
 
-        self.assertEqual(output,expected)
+        self.assertEqual(output, expected)
 
     def test_Source(self):
         name = "source.txt"
-        newfile = ruby.rubySource(self.testfile,name)
+        newfile = ruby.rubySource(self.testfile, name)
 
         self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_rust.py
+++ b/nirjas/languages/tests/test_rust.py
@@ -1,45 +1,43 @@
 import unittest
 import os
 from nirjas.languages import rust
-from nirjas.binder import readSingleLine,readMultiLineDiff,contSingleLines
+from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class RustTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.rs")
 
     def test_output(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '//'
-        comment_single = rust.readSingleLine(self.testfile,regex,sign)
-        comment_multiline = rust.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        comment_single = rust.readSingleLine(self.testfile, regex, sign)
+        comment_multiline = rust.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = rust.contSingleLines(comment_single)
         self.assertTrue(comment_single)
         self.assertTrue(comment_multiline)
         self.assertTrue(comment_contSingleline)
 
-
-
     def test_outputFormat(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '//'
-        expected = rust.rustExtractor(self.testfile)
-        comment_single = readSingleLine(self.testfile,regex,sign)
-        comment_multiline = readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        expected = rust.rustExtractor(self.testfile).get_dict()
+        comment_single = readSingleLine(self.testfile, regex, sign)
+        comment_multiline = readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = contSingleLines(comment_single)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "Rust",
         "total_lines": comment_single[1],
-        "total_lines_of_comments": comment_single[3]+comment_multiline[3],
+        "total_lines_of_comments": comment_single[3] + comment_multiline[3],
         "blank_lines": comment_single[2],
-        "sloc": comment_single[1]-(comment_single[3]+comment_multiline[3]+comment_single[2])
-        }],
+        "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2])
+        },
         "single_line_comment": [],
         "cont_single_line_comment": [],
         "multi_line_comment": []
@@ -50,20 +48,20 @@ class RustTest(unittest.TestCase):
 
         if comment_single:
             for i in comment_single[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
         if comment_contSingleline:
-            for idx,i in enumerate(comment_contSingleline[1]):
+            for idx, i in enumerate(comment_contSingleline[1]):
                 output['cont_single_line_comment'].append({"start_line": comment_contSingleline[1][idx], "end_line": comment_contSingleline[2][idx], "comment": comment_contSingleline[3][idx]})
 
         if comment_multiline:
-            for idx,i in enumerate(comment_multiline[0]):
+            for idx, i in enumerate(comment_multiline[0]):
                 output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
 
-        self.assertEqual(output,expected)
+        self.assertEqual(output, expected)
 
     def test_Source(self):
         name = "source.txt"
-        newfile = rust.rustSource(self.testfile,name)
+        newfile = rust.rustSource(self.testfile, name)
 
         self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_scala.py
+++ b/nirjas/languages/tests/test_scala.py
@@ -1,45 +1,43 @@
 import unittest
 import os
 from nirjas.languages import scala
-from nirjas.binder import readSingleLine,readMultiLineDiff,contSingleLines
+from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class ScalaTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.scala")
 
     def test_output(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '//'
-        comment_single = scala.readSingleLine(self.testfile,regex,sign)
-        comment_multiline = scala.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        comment_single = scala.readSingleLine(self.testfile, regex, sign)
+        comment_multiline = scala.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = scala.contSingleLines(comment_single)
         self.assertTrue(comment_single)
         self.assertTrue(comment_multiline)
         self.assertTrue(comment_contSingleline)
 
-
-
     def test_outputFormat(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '//'
-        expected = scala.scalaExtractor(self.testfile)
-        comment_single = readSingleLine(self.testfile,regex,sign)
-        comment_multiline = readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        expected = scala.scalaExtractor(self.testfile).get_dict()
+        comment_single = readSingleLine(self.testfile, regex, sign)
+        comment_multiline = readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = contSingleLines(comment_single)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "Scala",
         "total_lines": comment_single[1],
-        "total_lines_of_comments": comment_single[3]+comment_multiline[3],
+        "total_lines_of_comments": comment_single[3] + comment_multiline[3],
         "blank_lines": comment_single[2],
-        "sloc": comment_single[1]-(comment_single[3]+comment_multiline[3]+comment_single[2])
-        }],
+        "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2])
+        },
         "single_line_comment": [],
         "cont_single_line_comment": [],
         "multi_line_comment": []
@@ -50,20 +48,20 @@ class ScalaTest(unittest.TestCase):
 
         if comment_single:
             for i in comment_single[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
         if comment_contSingleline:
-            for idx,i in enumerate(comment_contSingleline[1]):
+            for idx, i in enumerate(comment_contSingleline[1]):
                 output['cont_single_line_comment'].append({"start_line": comment_contSingleline[1][idx], "end_line": comment_contSingleline[2][idx], "comment": comment_contSingleline[3][idx]})
 
         if comment_multiline:
-            for idx,i in enumerate(comment_multiline[0]):
+            for idx, i in enumerate(comment_multiline[0]):
                 output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
 
-        self.assertEqual(output,expected)
+        self.assertEqual(output, expected)
 
     def test_Source(self):
         name = "source.txt"
-        newfile = scala.scalaSource(self.testfile,name)
+        newfile = scala.scalaSource(self.testfile, name)
 
         self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_scss.py
+++ b/nirjas/languages/tests/test_scss.py
@@ -21,21 +21,22 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 import unittest
 import os
 from nirjas.languages import scss
-from nirjas.binder import readSingleLine,readMultiLineDiff
+from nirjas.binder import readSingleLine, readMultiLineDiff
+
 
 class ScssTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.scss")
 
     def test_output(self):
-        regex1 = r'''((?<!\/)\/\/(?!\/)\s*[\w #\.()@+-_*\d]*)'''
-        regex2 = r'''(\/\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex1 = r'''(?<!\/)\/\/(?!\/)\s*(.*)'''
+        regex2 = r'''\/\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign1 = '//'
         sign2 = '///'
-        comment_single_doubleSlash = scss.readSingleLine(self.testfile,regex1,sign1)
-        comment_single_tripleSlash = scss.readSingleLine(self.testfile,regex2,sign2)
-        comment_multiline = scss.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        comment_single_doubleSlash = scss.readSingleLine(self.testfile, regex1, sign1)
+        comment_single_tripleSlash = scss.readSingleLine(self.testfile, regex2, sign2)
+        comment_multiline = scss.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline1 = scss.contSingleLines(comment_single_doubleSlash)
         comment_contSingleline2 = scss.contSingleLines(comment_single_tripleSlash)
         self.assertTrue(comment_single_doubleSlash)
@@ -44,30 +45,29 @@ class ScssTest(unittest.TestCase):
         self.assertTrue(comment_contSingleline1)
         self.assertTrue(comment_contSingleline2)
 
-
     def test_outputFormat(self):
-        regex1 = r'''((?<!\/)\/\/(?!\/)\s*[\w #\.()@+-_*\d]*)'''
-        regex2 = r'''(\/\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex1 = r'''(?<!\/)\/\/(?!\/)\s*(.*)'''
+        regex2 = r'''\/\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign1 = '//'
         sign2 = '///'
-        expected = scss.scssExtractor(self.testfile)
-        comment_single_doubleSlash = scss.readSingleLine(self.testfile,regex1,sign1)
-        comment_single_tripleSlash = scss.readSingleLine(self.testfile,regex2,sign2)
-        comment_multiline = scss.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        expected = scss.scssExtractor(self.testfile).get_dict()
+        comment_single_doubleSlash = scss.readSingleLine(self.testfile, regex1, sign1)
+        comment_single_tripleSlash = scss.readSingleLine(self.testfile, regex2, sign2)
+        comment_multiline = scss.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline1 = scss.contSingleLines(comment_single_doubleSlash)
         comment_contSingleline2 = scss.contSingleLines(comment_single_tripleSlash)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "Scss",
         "total_lines": comment_single_doubleSlash[1],
-        "total_lines_of_comments": comment_single_doubleSlash[3]+comment_single_tripleSlash[3]+comment_multiline[3],
+        "total_lines_of_comments": comment_single_doubleSlash[3] + comment_single_tripleSlash[3] + comment_multiline[3],
         "blank_lines": comment_single_doubleSlash[2],
-        "sloc": comment_single_doubleSlash[1]-(comment_single_doubleSlash[3]+comment_single_tripleSlash[3]+comment_multiline[3]+comment_single_doubleSlash[2])
-        }],
+        "sloc": comment_single_doubleSlash[1] - (comment_single_doubleSlash[3] + comment_single_tripleSlash[3] + comment_multiline[3] + comment_single_doubleSlash[2])
+        },
         "single_line_comment": [],
         "cont_single_line_comment": [],
         "multi_line_comment": []
@@ -81,31 +81,31 @@ class ScssTest(unittest.TestCase):
 
         if comment_single_doubleSlash:
             for i in comment_single_doubleSlash[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
         if comment_single_tripleSlash:
             for i in comment_single_tripleSlash[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
         if comment_contSingleline1:
-            for idx,i in enumerate(comment_contSingleline1[1]):
+            for idx, i in enumerate(comment_contSingleline1[1]):
                 output['cont_single_line_comment'].append({"start_line": comment_contSingleline1[1][idx], "end_line": comment_contSingleline1[2][idx], "comment": comment_contSingleline1[3][idx]})
 
         if comment_contSingleline2:
-            for idx,i in enumerate(comment_contSingleline2[1]):
+            for idx, i in enumerate(comment_contSingleline2[1]):
                 output['cont_single_line_comment'].append({"start_line": comment_contSingleline2[1][idx], "end_line": comment_contSingleline2[2][idx], "comment": comment_contSingleline2[3][idx]})
 
         if comment_multiline:
             try:
-                for idx,i in enumerate(comment_multiline[0]):
+                for idx, i in enumerate(comment_multiline[0]):
                     output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
             except:
                 pass
 
-        self.assertEqual(output,expected)
+        self.assertEqual(output, expected)
 
     def test_Source(self):
         name = "source.txt"
-        newfile = scss.scssSource(self.testfile,name)
+        newfile = scss.scssSource(self.testfile, name)
 
         self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_shell.py
+++ b/nirjas/languages/tests/test_shell.py
@@ -8,38 +8,46 @@ class ShellTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.sh")
 
     def test_output(self):
-        regex = r'''(#+\s*[\!\w #\.()@+-_*\d]*)'''
+        regex = r'''#+\s*(.*)'''
         sign = '#'
-        comment_single = shell.readSingleLine(self.testfile,regex,sign)
+        comment_single = shell.readSingleLine(self.testfile, regex, sign)
         self.assertTrue(comment_single)
 
-
-
     def test_outputFormat(self):
-        regex = r'''(#+\s*[\!\w #\.()@+-_*\d]*)'''
-        expected = shell.shellExtractor(self.testfile)
+        regex = r'''#+\s*(.*)'''
+        expected = shell.shellExtractor(self.testfile).get_dict()
         sign = '#'
-        comment_single = readSingleLine(self.testfile,regex,sign)
+        comment_single = readSingleLine(self.testfile, regex, sign)
+        comment_contSingleline = shell.contSingleLines(comment_single)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "Shell",
         "total_lines": comment_single[1],
         "total_lines_of_comments": comment_single[3],
         "blank_lines": comment_single[2],
-        "sloc": comment_single[1]-(comment_single[3]+comment_single[2])
-        }],
+        "sloc": comment_single[1] - (comment_single[3] + comment_single[2])
+        },
         "single_line_comment": [],
+        "cont_single_line_comment": [],
         "multi_line_comment": []
         }
+        if comment_contSingleline:
+            comment_single = comment_contSingleline[0]
+
         if comment_single:
             for i in comment_single[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
-        self.assertEqual(output,expected)
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
+
+        if comment_contSingleline:
+            for idx, i in enumerate(comment_contSingleline[1]):
+                output['cont_single_line_comment'].append({"start_line": comment_contSingleline[1][idx], "end_line": comment_contSingleline[2][idx], "comment": comment_contSingleline[3][idx]})
+
+        self.assertEqual(output, expected)
 
     def test_Source(self):
         name = "source.txt"
-        newfile = shell.shellSource(self.testfile,name)
+        newfile = shell.shellSource(self.testfile, name)
 
         self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_swift.py
+++ b/nirjas/languages/tests/test_swift.py
@@ -1,45 +1,43 @@
 import unittest
 import os
 from nirjas.languages import swift
-from nirjas.binder import readSingleLine,readMultiLineDiff,contSingleLines
+from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class SwiftTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.swift")
 
     def test_output(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         sign = '//'
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
-        comment_single = swift.readSingleLine(self.testfile,regex,sign)
-        comment_multiline = swift.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        self.syntax_end = '*/'
+        comment_single = swift.readSingleLine(self.testfile, regex, sign)
+        comment_multiline = swift.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = swift.contSingleLines(comment_single)
         self.assertTrue(comment_single)
         self.assertTrue(comment_multiline)
         self.assertTrue(comment_contSingleline)
 
-
-
     def test_outputFormat(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
         self.syntax_end = "*/"
         sign = '//'
-        expected = swift.swiftExtractor(self.testfile)
-        comment_single = readSingleLine(self.testfile,regex,sign)
-        comment_multiline = readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        expected = swift.swiftExtractor(self.testfile).get_dict()
+        comment_single = readSingleLine(self.testfile, regex, sign)
+        comment_multiline = readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = contSingleLines(comment_single)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "Swift",
         "total_lines": comment_single[1],
-        "total_lines_of_comments": comment_single[3]+comment_multiline[3],
+        "total_lines_of_comments": comment_single[3] + comment_multiline[3],
         "blank_lines": comment_single[2],
-        "sloc": comment_single[1]-(comment_single[3]+comment_multiline[3]+comment_single[2])
-        }],
+        "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2])
+        },
         "single_line_comment": [],
         "cont_single_line_comment": [],
         "multi_line_comment": []
@@ -50,20 +48,20 @@ class SwiftTest(unittest.TestCase):
 
         if comment_single:
             for i in comment_single[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+                output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
         if comment_contSingleline:
-            for idx,i in enumerate(comment_contSingleline[1]):
+            for idx, i in enumerate(comment_contSingleline[1]):
                 output['cont_single_line_comment'].append({"start_line": comment_contSingleline[1][idx], "end_line": comment_contSingleline[2][idx], "comment": comment_contSingleline[3][idx]})
 
         if comment_multiline:
-            for idx,i in enumerate(comment_multiline[0]):
+            for idx, i in enumerate(comment_multiline[0]):
                 output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
-        
-        self.assertEqual(output,expected)
+
+        self.assertEqual(output, expected)
 
     def test_Source(self):
         name = "source.txt"
-        newfile = swift.swiftSource(self.testfile,name)
+        newfile = swift.swiftSource(self.testfile, name)
 
         self.assertTrue(newfile)

--- a/nirjas/languages/tests/test_typescript.py
+++ b/nirjas/languages/tests/test_typescript.py
@@ -21,43 +21,43 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 import unittest
 import os
 from nirjas.languages import typescript
-from nirjas.binder import readSingleLine,readMultiLineDiff
+from nirjas.binder import readSingleLine, readMultiLineDiff
+
 
 class TSTest(unittest.TestCase):
     testfile = os.path.join(os.path.abspath(os.path.dirname(__file__)), "TestFiles/textcomment.ts")
 
     def test_output(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '//'
-        comment_single = typescript.readSingleLine(self.testfile,regex,sign)
-        comment_multiline = typescript.readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        comment_single = typescript.readSingleLine(self.testfile, regex, sign)
+        comment_multiline = typescript.readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = typescript.contSingleLines(comment_single)
         self.assertTrue(comment_single)
         self.assertTrue(comment_multiline)
         self.assertTrue(comment_contSingleline)
 
-
     def test_outputFormat(self):
-        regex = r'''(\/\/\s*[\w #\.()@+-_*\d]*)'''
+        regex = r'''(?<![pst]:)\/\/\s*(.*)'''
         self.syntax_start = "/*"
-        self.syntax_end ='*/'
+        self.syntax_end = '*/'
         sign = '//'
-        expected = typescript.typescriptExtractor(self.testfile)
-        comment_single = readSingleLine(self.testfile,regex,sign)
-        comment_multiline = readMultiLineDiff(self.testfile,self.syntax_start,self.syntax_end)
+        expected = typescript.typescriptExtractor(self.testfile).get_dict()
+        comment_single = readSingleLine(self.testfile, regex, sign)
+        comment_multiline = readMultiLineDiff(self.testfile, self.syntax_start, self.syntax_end)
         comment_contSingleline = typescript.contSingleLines(comment_single)
         file = self.testfile.split("/")
         output = {
-        "metadata": [{
+        "metadata": {
         "filename": file[-1],
         "lang": "TypeScript",
         "total_lines": comment_single[1],
-        "total_lines_of_comments": comment_single[3]+comment_multiline[3],
+        "total_lines_of_comments": comment_single[3] + comment_multiline[3],
         "blank_lines": comment_single[2],
-        "sloc": comment_single[1]-(comment_single[3]+comment_multiline[3]+comment_single[2])
-        }],
+        "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2])
+        },
         "single_line_comment": [],
         "cont_single_line_comment": [],
         "multi_line_comment": []
@@ -66,25 +66,22 @@ class TSTest(unittest.TestCase):
         if comment_contSingleline:
             comment_single = comment_contSingleline[0]
 
-        if comment_single:
-            for i in comment_single[0]:
-                output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+        for i in comment_single[0]:
+            output['single_line_comment'].append({"line_number":i[0], "comment": i[1]})
 
-        if comment_contSingleline:
-            for idx,i in enumerate(comment_contSingleline[1]):
-                output['cont_single_line_comment'].append({"start_line": comment_contSingleline[1][idx], "end_line": comment_contSingleline[2][idx], "comment": comment_contSingleline[3][idx]})
+        for idx, i in enumerate(comment_contSingleline[1]):
+            output['cont_single_line_comment'].append({"start_line": comment_contSingleline[1][idx], "end_line": comment_contSingleline[2][idx], "comment": comment_contSingleline[3][idx]})
 
-        if comment_multiline:
-            try:
-                for idx,i in enumerate(comment_multiline[0]):
-                    output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
-            except:
-                pass
+        try:
+            for idx, i in enumerate(comment_multiline[0]):
+                output['multi_line_comment'].append({"start_line": comment_multiline[0][idx], "end_line": comment_multiline[1][idx], "comment": comment_multiline[2][idx]})
+        except:
+            pass
 
-        self.assertEqual(output,expected)
+        self.assertEqual(output, expected)
 
     def test_Source(self):
         name = "source.txt"
-        newfile = typescript.typescriptSource(self.testfile,name)
+        newfile = typescript.typescriptSource(self.testfile, name)
 
-        self.assertTrue(newfile)  
+        self.assertTrue(newfile)

--- a/nirjas/languages/text.py
+++ b/nirjas/languages/text.py
@@ -20,36 +20,29 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
+from nirjas.output import ScanOutput, SingleLine, MultiLine
+
+
 def textExtractor(file):
-    result1 = []
     content = ""
-    total_lines, blank_lines = 0,0
+    total_lines, blank_lines = 0, 0
     with open(file) as f:
-        for lineNumber, line in enumerate(f, start=1):
+        for line_number, line in enumerate(f, start=1):
             total_lines += 1
-            content = content + line.replace('\n',' ')
-            if not line.strip():
+            line = line.strip()
+            content = content + line.replace('\n', ' ')
+            if line == '':
                 blank_lines += 1
 
-    result1.append(content)
+    file = file.split('/')
 
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'text'
+    output.total_lines = total_lines
+    output.total_lines_of_comments = total_lines - blank_lines
+    output.blank_lines = blank_lines
 
-    file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "text",
-        "total_lines": total_lines,
-        "total_lines_of_comments": total_lines-blank_lines,
-        "blank_lines": blank_lines,
-        "sloc": 0,
-        }],
-        "single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output.multi_line_comment.append(MultiLine(1, total_lines, content))
 
-    if result1 :
-        output['multi_line_comment'].append({"start_line": 1, "end_line": total_lines, "comment": result1[0]})
-    
     return output
-

--- a/nirjas/languages/text.py
+++ b/nirjas/languages/text.py
@@ -20,7 +20,7 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import ScanOutput, MultiLine
 
 
 def textExtractor(file):

--- a/nirjas/languages/typescript.py
+++ b/nirjas/languages/typescript.py
@@ -21,46 +21,43 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 from nirjas.binder import *
+from nirjas.output import ScanOutput, SingleLine, MultiLine
+
 
 def typescriptExtractor(file):
     result = CommentSyntax()
-    result1 = result.doubleSlash(file)
-    result2 = result.slashStar(file)
-    result4 = contSingleLines(result1)
+    single_line_comment = result.doubleSlash(file)
+    multiline_comment = result.slashStar(file)
+    cont_single_line_comment = contSingleLines(single_line_comment)
     file = file.split("/")
-    output = {
-        "metadata": [{
-        "filename": file[-1],
-        "lang": "TypeScript",
-        "total_lines": result1[1],
-        "total_lines_of_comments": result1[3]+result2[3],
-        "blank_lines": result1[2],
-        "sloc": result1[1]-(result1[3]+result2[3]+result1[2])
-        }],
-        "single_line_comment": [],
-        "cont_single_line_comment": [],
-        "multi_line_comment": []
-    }
+    output = ScanOutput()
+    output.filename = file[-1]
+    output.lang = 'TypeScript'
+    output.total_lines = single_line_comment[1]
+    output.total_lines_of_comments = single_line_comment[3] + multiline_comment[3]
+    output.blank_lines = single_line_comment[2]
 
-    if result4:
-        result1 = result4[0]
+    if cont_single_line_comment:
+        single_line_comment = cont_single_line_comment[0]
 
-    if result1:
-        for i in result1[0]:
-            output['single_line_comment'].append({"line_number" :i[0],"comment": i[1]})
+    for i in single_line_comment[0]:
+        output.single_line_comment.append(SingleLine(i[0], i[1]))
 
-    if result4:
-        for idx,i in enumerate(result4[1]):
-            output['cont_single_line_comment'].append({"start_line": result4[1][idx], "end_line": result4[2][idx], "comment": result4[3][idx]})
+    for idx, i in enumerate(cont_single_line_comment[1]):
+        output.cont_single_line_comment.append(MultiLine(
+            cont_single_line_comment[1][idx], cont_single_line_comment[2][idx],
+            cont_single_line_comment[3][idx]))
 
-    if result2:
-        try:
-            for idx,i in enumerate(result2[0]):
-                output['multi_line_comment'].append({"start_line": result2[0][idx], "end_line": result2[1][idx], "comment": result2[2][idx]})
-        except:
-            pass
+    try:
+        for idx, i in enumerate(multiline_comment[0]):
+            output.multi_line_comment.append(MultiLine(multiline_comment[0][idx],
+                                                       multiline_comment[1][idx],
+                                                       multiline_comment[2][idx]))
+    except:
+        pass
 
     return output
+
 
 def typescriptSource(file, newFile: str):
     closingCount = 0

--- a/nirjas/languages/typescript.py
+++ b/nirjas/languages/typescript.py
@@ -59,29 +59,35 @@ def typescriptExtractor(file):
     return output
 
 
-def typescriptSource(file, newFile: str):
-    closingCount = 0
+def typescriptSource(file, new_file: str):
     copy = True
-    with open(newFile, 'w+') as f1:
+    with open(new_file, 'w+') as f1:
         with open(file) as f:
-            for lineNumber, line in enumerate(f, start=1):
-                if line.strip() == '/*':
-                    closingCount+=1
+            for line in f:
+                content = ""
+                found = False
+                if '/*' in line:
+                    pos = line.find('/*')
+                    content = line[:pos].rstrip()
+                    line = line[pos:]
                     copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if line.strip() == '*/':
-                    closingCount+=1
-                    copy = False
-                    if closingCount%2 == 0:
-                        copy = True
-
-                if copy:
-                    if line.strip() != '/*' and line.strip() != '*/':
-                        Templine = line.replace(" ","")
-                        if Templine[0:2] != "//":            # Syntax for single line comment
-                            f1.write(line)
+                    found = True
+                if '*/' in line:
+                    content = content + line[line.rfind('*/') + 2:]
+                    line = content
+                    copy = True
+                    found = True
+                if '//' in line:
+                    if line[line.find('//') - 1] != ':':
+                        line = line[:line.find('//')].rstrip() + '\n'
+                    elif line[line.rfind('//') - 1] != ':':
+                        line = line[:line.rfind('//')].rstrip() + '\n'
+                    content = line
+                    found = True
+                if not found:
+                    content = line
+                if copy and content.strip() != '':
+                    f1.write(content)
     f.close()
     f1.close()
-    return newFile
+    return new_file

--- a/nirjas/output/MultiLine.py
+++ b/nirjas/output/MultiLine.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+'''
+Copyright (C) 2020 Siemens AG
+Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+
+SPDX-License-Identifier: LGPL-2.1
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+'''
+
+
+class MultiLine:
+    '''
+    Store result for multi line comments
+    '''
+
+    def __init__(self, start, end, comment):
+        self.start_line = start
+        self.end_line = end
+        self.comment = comment
+
+    def get_dict(self):
+        '''
+        Get the output as dictionary
+        '''
+        return {
+            "start_line": self.start_line,
+            "end_line": self.end_line,
+            "comment": self.comment
+        }

--- a/nirjas/output/ScanOutput.py
+++ b/nirjas/output/ScanOutput.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+'''
+Copyright (C) 2020 Siemens AG
+Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+
+SPDX-License-Identifier: LGPL-2.1
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+'''
+
+class ScanOutput:
+    '''
+    Generate the output for a single file scan.
+    '''
+    filename = None
+    lang = None
+    total_lines = None
+    total_lines_of_comments = None
+    blank_lines = None
+    single_line_comment = list()
+    cont_single_line_comment = list()
+    multi_line_comment = list()
+
+    def get_dict(self):
+        '''
+        Get the output as dictionary
+        '''
+        return {
+            "metadata": {
+                "filename": self.filename,
+                "lang": self.lang,
+                "total_lines": self.total_lines,
+                "total_lines_of_comments": self.total_lines_of_comments,
+                "blank_lines": self.blank_lines,
+                "sloc": self.total_lines - (self.total_lines_of_comments + self.blank_lines)
+            },
+            "single_line_comment": [c.get_dict() for c in self.single_line_comment],
+            "cont_single_line_comment": [c.get_dict() for c in self.cont_single_line_comment],
+            "multi_line_comment": [c.get_dict() for c in self.multi_line_comment]
+        }

--- a/nirjas/output/SingleLine.py
+++ b/nirjas/output/SingleLine.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+'''
+Copyright (C) 2020 Siemens AG
+Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+
+SPDX-License-Identifier: LGPL-2.1
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+'''
+
+
+class SingleLine:
+    '''
+    Store result for single line comments
+    '''
+
+    def __init__(self, line_number, comment):
+        self.line_number = line_number
+        self.comment = comment
+
+    def get_dict(self):
+        '''
+        Get the output as dictionary
+        '''
+        return {
+            "line_number": self.line_number,
+            "comment": self.comment
+        }

--- a/nirjas/output/__init__.py
+++ b/nirjas/output/__init__.py
@@ -1,0 +1,3 @@
+from .ScanOutput import ScanOutput
+from .SingleLine import SingleLine
+from .MultiLine import MultiLine

--- a/nirjas/output/__init__.py
+++ b/nirjas/output/__init__.py
@@ -1,3 +1,3 @@
-from .ScanOutput import ScanOutput
-from .SingleLine import SingleLine
-from .MultiLine import MultiLine
+from .scan_output import ScanOutput
+from .single_line import SingleLine
+from .multi_line import MultiLine

--- a/nirjas/output/multi_line.py
+++ b/nirjas/output/multi_line.py
@@ -22,13 +22,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 
-class SingleLine:
+class MultiLine(object):
     '''
-    Store result for single line comments
+    Store result for multi line comments
     '''
 
-    def __init__(self, line_number, comment):
-        self.line_number = line_number
+    def __init__(self, start, end, comment):
+        self.start_line = start
+        self.end_line = end
         self.comment = comment
 
     def get_dict(self):
@@ -36,6 +37,7 @@ class SingleLine:
         Get the output as dictionary
         '''
         return {
-            "line_number": self.line_number,
+            "start_line": self.start_line,
+            "end_line": self.end_line,
             "comment": self.comment
         }

--- a/nirjas/output/scan_output.py
+++ b/nirjas/output/scan_output.py
@@ -21,18 +21,21 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
-class ScanOutput:
+
+class ScanOutput(object):
     '''
     Generate the output for a single file scan.
     '''
-    filename = None
-    lang = None
-    total_lines = None
-    total_lines_of_comments = None
-    blank_lines = None
-    single_line_comment = list()
-    cont_single_line_comment = list()
-    multi_line_comment = list()
+
+    def __init__(self):
+        self.filename = None
+        self.lang = None
+        self.total_lines = None
+        self.total_lines_of_comments = None
+        self.blank_lines = None
+        self.single_line_comment = list()
+        self.cont_single_line_comment = list()
+        self.multi_line_comment = list()
 
     def get_dict(self):
         '''

--- a/nirjas/output/single_line.py
+++ b/nirjas/output/single_line.py
@@ -22,14 +22,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 '''
 
 
-class MultiLine:
+class SingleLine(object):
     '''
-    Store result for multi line comments
+    Store result for single line comments
     '''
 
-    def __init__(self, start, end, comment):
-        self.start_line = start
-        self.end_line = end
+    def __init__(self, line_number, comment):
+        self.line_number = line_number
         self.comment = comment
 
     def get_dict(self):
@@ -37,7 +36,6 @@ class MultiLine:
         Get the output as dictionary
         '''
         return {
-            "start_line": self.start_line,
-            "end_line": self.end_line,
+            "line_number": self.line_number,
             "comment": self.comment
         }

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
-
 CLASSIFIERS = """\
 Development Status :: 4 - Beta
 License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)
@@ -36,7 +35,6 @@ Topic :: Utilities
 Topic :: Software Development
 Topic :: Text Processing
 """
-
 
 setup(
     name='Nirjas',
@@ -51,12 +49,12 @@ setup(
     classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
     keywords='Nirjas,Code Comment, Comment Extractor, Code Comment Extractor, Source Code Extractor, Source Extractor',
     packages=find_packages(),
-    python_requires = ">=3",
-    entry_points = {
+    python_requires=">=3",
+    entry_points={
         'console_scripts': [
-            'nirjas = nirjas.main:main'
+            'nirjas = nirjas.main:run_and_print'
         ]
     },
-    license = "LGPL-2.1-or-later",
-    platforms = ['any']
+    license="LGPL-2.1-or-later",
+    platforms=['any']
 )

--- a/testScript.py
+++ b/testScript.py
@@ -7,17 +7,17 @@ import os
 
 def download_files(cwd):
 
-    url = [
-        "https://raw.githubusercontent.com/apache/thrift/43f4bf2fdd13c7466e3fea690d436c6a9540f303/lib/c_glib/test/testbinaryprotocol.c",
+    urls = [
+        "https://raw.githubusercontent.com/fossology/fossology/6793719f9837fa6585744c09f9882a31024d26e9/src/lib/c/libfossdbmanager.c",
         "https://raw.githubusercontent.com/apache/thrift/43f4bf2fdd13c7466e3fea690d436c6a9540f303/lib/cpp/test/AnnotationTest.cpp",
         "https://raw.githubusercontent.com/apache/thrift/43f4bf2fdd13c7466e3fea690d436c6a9540f303/lib/go/test/tests/thrifttest_driver.go",
         "https://raw.githubusercontent.com/apache/thrift/43f4bf2fdd13c7466e3fea690d436c6a9540f303/lib/hs/test/JSONSpec.hs",
         "https://raw.githubusercontent.com/necolas/normalize.css/fc091cce1534909334c1911709a39c22d406977b/normalize.css",
         "https://raw.githubusercontent.com/apache/thrift/43f4bf2fdd13c7466e3fea690d436c6a9540f303/lib/java/test/org/apache/thrift/test/JavaBeansTest.java",
-        "https://raw.githubusercontent.com/apache/thrift/43f4bf2fdd13c7466e3fea690d436c6a9540f303/lib/js/test/test-async.js",
+        "https://raw.githubusercontent.com/apache/thrift/b5d6ea390fc5732ed1c1772709ab3731555dc3fc/lib/js/test/test-jq.js",
         "https://raw.githubusercontent.com/apache/thrift/8101f00b0966deebd36a6ba658aa59d718453345/lib/perl/tools/FixupDist.pl",
         "https://raw.githubusercontent.com/apache/thrift/9ea48f362a578ee8556fcf3ca84215cefbc1b99e/lib/php/test/Fixtures.php",
-        "https://raw.githubusercontent.com/apache/thrift/43f4bf2fdd13c7466e3fea690d436c6a9540f303/lib/py/test/test_sslsocket.py",
+        "https://raw.githubusercontent.com/apache/thrift/747158c8daa994b3386f1dcb4fc9e91aed1748ad/lib/py/src/protocol/TBinaryProtocol.py",
         "https://raw.githubusercontent.com/apache/thrift/43f4bf2fdd13c7466e3fea690d436c6a9540f303/lib/rb/benchmark/benchmark.rb",
         "https://raw.githubusercontent.com/apache/thrift/43f4bf2fdd13c7466e3fea690d436c6a9540f303/lib/rs/test/src/bin/kitchen_sink_client.rs",
         "https://raw.githubusercontent.com/apache/thrift/a082592d439d6aa578507ff52198038e5e08006d/lib/swift/Tests/ThriftTests/TFramedTransportTests.swift",
@@ -36,21 +36,19 @@ def download_files(cwd):
     ]
 
     directory = os.path.join(cwd, "nirjas/languages/tests/TestFiles")
+    os.makedirs(directory, exist_ok=True)
+    files = os.listdir(directory)
 
-    if not os.path.isdir(directory):
+    if len(files) != len(urls):
         print("Downloading test files")
-        os.mkdir(directory)
-        for i in url:
-            list_of = i.split(".")
-            ext = [list_of[-1]]
-            data = urllib.request.urlopen(i)
-
-            for j in range (len(ext)):
-                filename = "textcomment." + ext[j]
-                f = open(os.path.join(directory, filename), 'w')
+        for url in urls:
+            file_name = url.split(".")
+            ext = file_name[-1]
+            data = urllib.request.urlopen(url)
+            filename = "textcomment." + ext
+            with open(os.path.join(directory, filename), 'w') as f:
                 f.write(data.read().decode('utf-8'))
-                f.close
-                print(".", end="")
+            print(".", end="")
         print()
 
 

--- a/testScript.py
+++ b/testScript.py
@@ -47,11 +47,12 @@ def download_files(cwd):
 
             for j in range (len(ext)):
                 filename = "textcomment." + ext[j]
-                f = open(os.path.join(directory,filename),'w')
+                f = open(os.path.join(directory, filename), 'w')
                 f.write(data.read().decode('utf-8'))
                 f.close
                 print(".", end="")
         print()
+
 
 if __name__ == "__main__":
     here = os.path.abspath(os.path.dirname(__file__))
@@ -62,3 +63,4 @@ if __name__ == "__main__":
                                       pattern='test_*.py')
     result = test_runner.run(test_suite)
     exit(int(not result.wasSuccessful()))
+


### PR DESCRIPTION
1. Fix the regex for finding comments.
    - Do not capture the comment starting (`//` for example)
    - Capture everything using `.*` rather than specific classes (see #27)
    - Update regex to ignore if `//` is actually a part of URL by matching `(?<![pst]:)` (http://, https://, git://, ftp:// will be filtered out)
2. Fix if multiline comment starts and ends on the same line (see #14)
3. Adjust `*Source()` according to changes above.
4. Create new `output` module with different classes to keep output more consistent.
5. Fix test cases.

Closes #14
Closes #27