### PR TITLE
fix(module): fix import of LanguageMapper

### DIFF
--- a/nirjas/__init__.py
+++ b/nirjas/__init__.py
@@ -18,7 +18,8 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-from nirjas.main import file_runner  # noqa
+from nirjas.main import file_runner    # noqa
+from nirjas.main import LanguageMapper # noqa
 
 
 def extract(file):
@@ -31,4 +32,4 @@ def extract(file):
     return file_runner(file)  # noqa
 
 
-__all__ = ["file_runner", "extract", "LanguageMapper"]
+__all__ = ["file_runner", "extract"]

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ Topic :: Text Processing
 
 setup(
     name='Nirjas',
-    version='1.0.0',
+    version='1.0.1',
     description='A Python library to extract comments and source code out of your file(s)',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Replace the export of `LanguageMapper` in `__init__.py` to fix https://github.com/fossology/atarashi/issues/92