### PR TITLE
Apply black + isort code formatting tools

### DIFF
--- a/nirjas/__init__.py
+++ b/nirjas/__init__.py
@@ -18,8 +18,8 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-from nirjas.main import file_runner    # noqa
-from nirjas.main import LanguageMapper # noqa
+from nirjas.main import LanguageMapper  # noqa
+from nirjas.main import file_runner  # noqa
 
 
 def extract(file):

--- a/nirjas/binder.py
+++ b/nirjas/binder.py
@@ -130,7 +130,7 @@ def readMultiLineDiff(file, startSyntax: str, endSyntax: str):
             if startSyntax in line:
                 copy = True
                 startLine.append(lineNumber)
-                line = line[line.find(startSyntax) + len(startSyntax):]
+                line = line[line.find(startSyntax) + len(startSyntax) :]
             if endSyntax in line:
                 copy = False
                 line = line[: line.rfind(endSyntax) + len(endSyntax)]

--- a/nirjas/languages/c.py
+++ b/nirjas/languages/c.py
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def cExtractor(file):
@@ -98,7 +98,7 @@ def cSource(file, new_file: str):
                     copy = False
                     found = True
                 if "*/" in line:
-                    content = content + line[line.rfind("*/") + 2:]
+                    content = content + line[line.rfind("*/") + 2 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/c_sharp.py
+++ b/nirjas/languages/c_sharp.py
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def c_sharpExtractor(file):
@@ -95,7 +95,7 @@ def c_sharpSource(file, new_file: str):
                     copy = False
                     found = True
                 if "*/" in line:
-                    content = content + line[line.rfind("*/") + 2:]
+                    content = content + line[line.rfind("*/") + 2 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/cpp.py
+++ b/nirjas/languages/cpp.py
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def cppExtractor(file):
@@ -98,7 +98,7 @@ def cppSource(file, new_file: str):
                     copy = False
                     found = True
                 if "*/" in line:
-                    content = content + line[line.rfind("*/") + 2:]
+                    content = content + line[line.rfind("*/") + 2 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/css.py
+++ b/nirjas/languages/css.py
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax
-from nirjas.output import ScanOutput, MultiLine
+from nirjas.output import MultiLine, ScanOutput
 
 
 def cssExtractor(file):
@@ -81,7 +81,7 @@ def cssSource(file, new_file: str):
                     copy = False
                     found = True
                 if "*/" in line:
-                    content = content + line[line.rfind("*/") + 2:]
+                    content = content + line[line.rfind("*/") + 2 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/dart.py
+++ b/nirjas/languages/dart.py
@@ -21,7 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def dartExtractor(file):
@@ -116,7 +116,7 @@ def dartSource(file, new_file: str):
                     copy = False
                     found = True
                 if "*/" in line:
-                    content = content + line[line.rfind("*/") + 2:]
+                    content = content + line[line.rfind("*/") + 2 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/go.py
+++ b/nirjas/languages/go.py
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def goExtractor(file):
@@ -95,7 +95,7 @@ def goSource(file, new_file: str):
                     copy = False
                     found = True
                 if "*/" in line:
-                    content = content + line[line.rfind("*/") + 2:]
+                    content = content + line[line.rfind("*/") + 2 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/haskell.py
+++ b/nirjas/languages/haskell.py
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def haskellExtractor(file):
@@ -95,7 +95,7 @@ def haskellSource(file, new_file: str):
                     copy = False
                     found = True
                 if "-}" in line:
-                    content = content + line[line.rfind("-}") + 2:]
+                    content = content + line[line.rfind("-}") + 2 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/html.py
+++ b/nirjas/languages/html.py
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax
-from nirjas.output import ScanOutput, MultiLine
+from nirjas.output import MultiLine, ScanOutput
 
 
 def htmlExtractor(file):
@@ -96,7 +96,7 @@ def htmlSource(file, new_file: str):
                     copy = False
                     found = True
                 if "*/" in line:
-                    content = content + line[line.rfind("*/") + 2:]
+                    content = content + line[line.rfind("*/") + 2 :]
                     line = content
                     copy = True
                     found = True
@@ -107,7 +107,7 @@ def htmlSource(file, new_file: str):
                     copy = False
                     found = True
                 if "-->" in line:
-                    content = content + line[line.rfind("-->") + 3:]
+                    content = content + line[line.rfind("-->") + 3 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/java.py
+++ b/nirjas/languages/java.py
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def javaExtractor(file):
@@ -95,7 +95,7 @@ def javaSource(file, new_file: str):
                     copy = False
                     found = True
                 if "*/" in line:
-                    content = content + line[line.rfind("*/") + 2:]
+                    content = content + line[line.rfind("*/") + 2 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/javascript.py
+++ b/nirjas/languages/javascript.py
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def javascriptExtractor(file):
@@ -98,7 +98,7 @@ def javascriptSource(file, new_file: str):
                     copy = False
                     found = True
                 if "*/" in line:
-                    content = content + line[line.rfind("*/") + 2:]
+                    content = content + line[line.rfind("*/") + 2 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/julia.py
+++ b/nirjas/languages/julia.py
@@ -21,7 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def juliaExtractor(file):
@@ -44,7 +44,10 @@ def juliaExtractor(file):
     output.lang = "Julia"
     output.total_lines = single_line_comment[1]
     output.total_lines_of_comments = (
-        single_line_comment[3] + multiline_single_comment[3] + multiline_double_comment[3] + multiline_hashEqual_comment[3]
+        single_line_comment[3]
+        + multiline_single_comment[3]
+        + multiline_double_comment[3]
+        + multiline_hashEqual_comment[3]
     )
     output.blank_lines = single_line_comment[2]
 
@@ -126,7 +129,7 @@ def juliaSource(file, new_file: str):
                         copy = False
                         found = True
                     else:
-                        content = content + line[line.rfind('"""') + 3:]
+                        content = content + line[line.rfind('"""') + 3 :]
                         line = content
                         copy = True
                         found = True
@@ -138,7 +141,7 @@ def juliaSource(file, new_file: str):
                         copy = False
                         found = True
                     else:
-                        content = content + line[line.rfind("'''") + 3:]
+                        content = content + line[line.rfind("'''") + 3 :]
                         line = content
                         copy = True
                         found = True
@@ -149,7 +152,7 @@ def juliaSource(file, new_file: str):
                     copy = False
                     found = True
                 if "=#" in line:
-                    content = content + line[line.rfind("=#") + 2:]
+                    content = content + line[line.rfind("=#") + 2 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/kotlin.py
+++ b/nirjas/languages/kotlin.py
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def kotlinExtractor(file):
@@ -95,7 +95,7 @@ def kotlinSource(file, new_file: str):
                     copy = False
                     found = True
                 if "*/" in line:
-                    content = content + line[line.rfind("*/") + 2:]
+                    content = content + line[line.rfind("*/") + 2 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/matlab.py
+++ b/nirjas/languages/matlab.py
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def matlabExtractor(file):
@@ -95,7 +95,7 @@ def matlabSource(file, new_file: str):
                     copy = False
                     found = True
                 if "}%" in line:
-                    content = content + line[line.rfind("}%") + 2:]
+                    content = content + line[line.rfind("}%") + 2 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/perl.py
+++ b/nirjas/languages/perl.py
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def perlExtractor(file):
@@ -95,7 +95,7 @@ def perlSource(file, new_file: str):
                     copy = False
                     found = True
                 if "=cut" in line:
-                    content = content + line[line.rfind("=cut") + 4:]
+                    content = content + line[line.rfind("=cut") + 4 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/php.py
+++ b/nirjas/languages/php.py
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def phpExtractor(file):
@@ -95,7 +95,7 @@ def phpSource(file, new_file: str):
                     copy = False
                     found = True
                 if "*/" in line:
-                    content = content + line[line.rfind("*/") + 2:]
+                    content = content + line[line.rfind("*/") + 2 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/python.py
+++ b/nirjas/languages/python.py
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def pythonExtractor(file):
@@ -44,7 +44,10 @@ def pythonExtractor(file):
     output.lang = "Python"
     output.total_lines = single_line_comment[1]
     output.total_lines_of_comments = (
-        single_line_comment[3] + multiline_single_comment[3] + multiline_double_comment[3])
+        single_line_comment[3]
+        + multiline_single_comment[3]
+        + multiline_double_comment[3]
+    )
     output.blank_lines = single_line_comment[2]
 
     if cont_single_line_comment:
@@ -113,7 +116,7 @@ def pythonSource(file, new_file: str):
                         copy = False
                         found = True
                     else:
-                        content = content + line[line.rfind('"""') + 3:]
+                        content = content + line[line.rfind('"""') + 3 :]
                         line = content
                         copy = True
                         found = True
@@ -125,7 +128,7 @@ def pythonSource(file, new_file: str):
                         copy = False
                         found = True
                     else:
-                        content = content + line[line.rfind("'''") + 3:]
+                        content = content + line[line.rfind("'''") + 3 :]
                         line = content
                         copy = True
                         found = True

--- a/nirjas/languages/ruby.py
+++ b/nirjas/languages/ruby.py
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def rubyExtractor(file):
@@ -95,7 +95,7 @@ def rubySource(file, new_file: str):
                     copy = False
                     found = True
                 if "=end" in line:
-                    content = content + line[line.rfind("=end") + 4:]
+                    content = content + line[line.rfind("=end") + 4 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/rust.py
+++ b/nirjas/languages/rust.py
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def rustExtractor(file):
@@ -95,7 +95,7 @@ def rustSource(file, new_file: str):
                     copy = False
                     found = True
                 if "*/" in line:
-                    content = content + line[line.rfind("*/") + 2:]
+                    content = content + line[line.rfind("*/") + 2 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/scala.py
+++ b/nirjas/languages/scala.py
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def scalaExtractor(file):
@@ -95,7 +95,7 @@ def scalaSource(file, new_file: str):
                     copy = False
                     found = True
                 if "*/" in line:
-                    content = content + line[line.rfind("*/") + 2:]
+                    content = content + line[line.rfind("*/") + 2 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/scss.py
+++ b/nirjas/languages/scss.py
@@ -21,7 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def scssExtractor(file):
@@ -116,7 +116,7 @@ def scssSource(file, new_file: str):
                     copy = False
                     found = True
                 if "*/" in line:
-                    content = content + line[line.rfind("*/") + 2:]
+                    content = content + line[line.rfind("*/") + 2 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/shell.py
+++ b/nirjas/languages/shell.py
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def shellExtractor(file):

--- a/nirjas/languages/sql.py
+++ b/nirjas/languages/sql.py
@@ -17,7 +17,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def sqlExtractor(file):
@@ -37,8 +37,7 @@ def sqlExtractor(file):
     output.filename = file[-1]
     output.lang = "SQL"
     output.total_lines = single_line_comment[1]
-    output.total_lines_of_comments = single_line_comment[3] + \
-        multiline_comment[3]
+    output.total_lines_of_comments = single_line_comment[3] + multiline_comment[3]
     output.blank_lines = single_line_comment[2]
 
     if cont_single_line_comment:
@@ -90,7 +89,7 @@ def sqlSource(file, new_file: str):
                     copy = False
                     found = True
                 if "*/" in line:
-                    content = content + line[line.rfind("*/") + 2:]
+                    content = content + line[line.rfind("*/") + 2 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/swift.py
+++ b/nirjas/languages/swift.py
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def swiftExtractor(file):
@@ -95,7 +95,7 @@ def swiftSource(file, new_file: str):
                     copy = False
                     found = True
                 if "*/" in line:
-                    content = content + line[line.rfind("*/") + 2:]
+                    content = content + line[line.rfind("*/") + 2 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/languages/tests/test_c.py
+++ b/nirjas/languages/tests/test_c.py
@@ -18,10 +18,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import contSingleLines, readMultiLineDiff, readSingleLine
 from nirjas.languages import c
-from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class CTest(unittest.TestCase):
@@ -67,7 +68,8 @@ class CTest(unittest.TestCase):
                 "total_lines": comment_single[1],
                 "total_lines_of_comments": comment_single[3] + comment_multiline[3],
                 "blank_lines": comment_single[2],
-                "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2]),
+                "sloc": comment_single[1]
+                - (comment_single[3] + comment_multiline[3] + comment_single[2]),
             },
             "single_line_comment": [],
             "cont_single_line_comment": [],

--- a/nirjas/languages/tests/test_c_sharp.py
+++ b/nirjas/languages/tests/test_c_sharp.py
@@ -18,10 +18,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import contSingleLines, readMultiLineDiff, readSingleLine
 from nirjas.languages import c_sharp
-from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class CSharpTest(unittest.TestCase):
@@ -68,7 +69,8 @@ class CSharpTest(unittest.TestCase):
                 "total_lines": comment_single[1],
                 "total_lines_of_comments": comment_single[3] + comment_multiline[3],
                 "blank_lines": comment_single[2],
-                "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2]),
+                "sloc": comment_single[1]
+                - (comment_single[3] + comment_multiline[3] + comment_single[2]),
             },
             "single_line_comment": [],
             "cont_single_line_comment": [],

--- a/nirjas/languages/tests/test_cpp.py
+++ b/nirjas/languages/tests/test_cpp.py
@@ -18,10 +18,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import contSingleLines, readMultiLineDiff, readSingleLine
 from nirjas.languages import cpp
-from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class CPPTest(unittest.TestCase):
@@ -67,7 +68,8 @@ class CPPTest(unittest.TestCase):
                 "total_lines": comment_single[1],
                 "total_lines_of_comments": comment_single[3] + comment_multiline[3],
                 "blank_lines": comment_single[2],
-                "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2]),
+                "sloc": comment_single[1]
+                - (comment_single[3] + comment_multiline[3] + comment_single[2]),
             },
             "single_line_comment": [],
             "cont_single_line_comment": [],

--- a/nirjas/languages/tests/test_css.py
+++ b/nirjas/languages/tests/test_css.py
@@ -18,10 +18,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
-from nirjas.languages import css
+import unittest
+
 from nirjas.binder import readMultiLineDiff
+from nirjas.languages import css
 
 
 class CssTest(unittest.TestCase):
@@ -60,7 +61,8 @@ class CssTest(unittest.TestCase):
                 "total_lines": comment_multiline[4],
                 "total_lines_of_comments": comment_multiline[3],
                 "blank_lines": comment_multiline[5],
-                "sloc": comment_multiline[4] - (comment_multiline[3] + comment_multiline[5]),
+                "sloc": comment_multiline[4]
+                - (comment_multiline[3] + comment_multiline[5]),
             },
             "single_line_comment": [],
             "cont_single_line_comment": [],

--- a/nirjas/languages/tests/test_dart.py
+++ b/nirjas/languages/tests/test_dart.py
@@ -20,10 +20,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import readMultiLineDiff, readSingleLine
 from nirjas.languages import dart
-from nirjas.binder import readSingleLine, readMultiLineDiff
 
 
 class DartTest(unittest.TestCase):
@@ -75,10 +76,16 @@ class DartTest(unittest.TestCase):
                 "filename": file[-1],
                 "lang": "Dart",
                 "total_lines": comment_single_doubleSlash[1],
-                "total_lines_of_comments": comment_single_doubleSlash[3] + comment_single_tripleSlash[3] + comment_multiline[3],
+                "total_lines_of_comments": comment_single_doubleSlash[3]
+                + comment_single_tripleSlash[3]
+                + comment_multiline[3],
                 "blank_lines": comment_single_doubleSlash[2],
-                "sloc": comment_single_doubleSlash[1] - (
-                    comment_single_doubleSlash[3] + comment_single_tripleSlash[3] + comment_multiline[3] + comment_single_doubleSlash[2]
+                "sloc": comment_single_doubleSlash[1]
+                - (
+                    comment_single_doubleSlash[3]
+                    + comment_single_tripleSlash[3]
+                    + comment_multiline[3]
+                    + comment_single_doubleSlash[2]
                 ),
             },
             "single_line_comment": [],

--- a/nirjas/languages/tests/test_go.py
+++ b/nirjas/languages/tests/test_go.py
@@ -18,10 +18,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import contSingleLines, readMultiLineDiff, readSingleLine
 from nirjas.languages import go
-from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class GoTest(unittest.TestCase):
@@ -67,7 +68,8 @@ class GoTest(unittest.TestCase):
                 "total_lines": comment_single[1],
                 "total_lines_of_comments": comment_single[3] + comment_multiline[3],
                 "blank_lines": comment_single[2],
-                "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2]),
+                "sloc": comment_single[1]
+                - (comment_single[3] + comment_multiline[3] + comment_single[2]),
             },
             "single_line_comment": [],
             "cont_single_line_comment": [],

--- a/nirjas/languages/tests/test_haskell.py
+++ b/nirjas/languages/tests/test_haskell.py
@@ -18,10 +18,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import contSingleLines, readMultiLineDiff, readSingleLine
 from nirjas.languages import haskell
-from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class HaskellTest(unittest.TestCase):
@@ -67,7 +68,8 @@ class HaskellTest(unittest.TestCase):
                 "total_lines": comment_single[1],
                 "total_lines_of_comments": comment_single[3] + comment_multiline[3],
                 "blank_lines": comment_single[2],
-                "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2]),
+                "sloc": comment_single[1]
+                - (comment_single[3] + comment_multiline[3] + comment_single[2]),
             },
             "single_line_comment": [],
             "cont_single_line_comment": [],

--- a/nirjas/languages/tests/test_html.py
+++ b/nirjas/languages/tests/test_html.py
@@ -18,10 +18,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
-from nirjas.languages import html
+import unittest
+
 from nirjas.binder import readMultiLineDiff
+from nirjas.languages import html
 
 
 class HTMLTest(unittest.TestCase):
@@ -71,7 +72,8 @@ class HTMLTest(unittest.TestCase):
                 "total_lines": comment_single[4],
                 "total_lines_of_comments": comment_single[3] + comment_multiline[3],
                 "blank_lines": comment_single[5],
-                "sloc": comment_single[4] - (comment_single[3] + comment_multiline[3] + comment_single[5]),
+                "sloc": comment_single[4]
+                - (comment_single[3] + comment_multiline[3] + comment_single[5]),
             },
             "single_line_comment": [],
             "cont_single_line_comment": [],

--- a/nirjas/languages/tests/test_java.py
+++ b/nirjas/languages/tests/test_java.py
@@ -18,10 +18,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import contSingleLines, readMultiLineDiff, readSingleLine
 from nirjas.languages import java
-from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class JavaTest(unittest.TestCase):
@@ -67,7 +68,8 @@ class JavaTest(unittest.TestCase):
                 "total_lines": comment_single[1],
                 "total_lines_of_comments": comment_single[3] + comment_multiline[3],
                 "blank_lines": comment_single[2],
-                "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2]),
+                "sloc": comment_single[1]
+                - (comment_single[3] + comment_multiline[3] + comment_single[2]),
             },
             "single_line_comment": [],
             "cont_single_line_comment": [],

--- a/nirjas/languages/tests/test_javascript.py
+++ b/nirjas/languages/tests/test_javascript.py
@@ -18,10 +18,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import contSingleLines, readMultiLineDiff, readSingleLine
 from nirjas.languages import javascript
-from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class JSTest(unittest.TestCase):
@@ -67,7 +68,8 @@ class JSTest(unittest.TestCase):
                 "total_lines": comment_single[1],
                 "total_lines_of_comments": comment_single[3] + comment_multiline[3],
                 "blank_lines": comment_single[2],
-                "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2]),
+                "sloc": comment_single[1]
+                - (comment_single[3] + comment_multiline[3] + comment_single[2]),
             },
             "single_line_comment": [],
             "cont_single_line_comment": [],

--- a/nirjas/languages/tests/test_julia.py
+++ b/nirjas/languages/tests/test_julia.py
@@ -18,10 +18,12 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import (contSingleLines, readMultiLineDiff,
+                           readMultiLineSame, readSingleLine)
 from nirjas.languages import julia
-from nirjas.binder import readSingleLine, readMultiLineSame, readMultiLineDiff, contSingleLines
 
 
 class JuliaTest(unittest.TestCase):
@@ -79,10 +81,18 @@ class JuliaTest(unittest.TestCase):
                 "filename": file[-1],
                 "lang": "Julia",
                 "total_lines": comment_single[1],
-                "total_lines_of_comments": comment_single[3] + comment_multi_single[3] + comment_multi_double[3] + comment_multi_hashEqual[3],
+                "total_lines_of_comments": comment_single[3]
+                + comment_multi_single[3]
+                + comment_multi_double[3]
+                + comment_multi_hashEqual[3],
                 "blank_lines": comment_single[2],
-                "sloc": comment_single[1] - (
-                    comment_single[3] + comment_multi_single[3] + comment_multi_double[3] + comment_multi_hashEqual[3] + comment_single[2]
+                "sloc": comment_single[1]
+                - (
+                    comment_single[3]
+                    + comment_multi_single[3]
+                    + comment_multi_double[3]
+                    + comment_multi_hashEqual[3]
+                    + comment_single[2]
                 ),
             },
             "single_line_comment": [],

--- a/nirjas/languages/tests/test_kotlin.py
+++ b/nirjas/languages/tests/test_kotlin.py
@@ -18,10 +18,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import contSingleLines, readMultiLineDiff, readSingleLine
 from nirjas.languages import kotlin
-from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class KotlinTest(unittest.TestCase):
@@ -67,7 +68,8 @@ class KotlinTest(unittest.TestCase):
                 "total_lines": comment_single[1],
                 "total_lines_of_comments": comment_single[3] + comment_multiline[3],
                 "blank_lines": comment_single[2],
-                "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2]),
+                "sloc": comment_single[1]
+                - (comment_single[3] + comment_multiline[3] + comment_single[2]),
             },
             "single_line_comment": [],
             "cont_single_line_comment": [],

--- a/nirjas/languages/tests/test_matlab.py
+++ b/nirjas/languages/tests/test_matlab.py
@@ -18,10 +18,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import contSingleLines, readMultiLineDiff, readSingleLine
 from nirjas.languages import matlab
-from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class matlabTest(unittest.TestCase):
@@ -67,7 +68,8 @@ class matlabTest(unittest.TestCase):
                 "total_lines": comment_single[1],
                 "total_lines_of_comments": comment_single[3] + comment_multiline[3],
                 "blank_lines": comment_single[2],
-                "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2]),
+                "sloc": comment_single[1]
+                - (comment_single[3] + comment_multiline[3] + comment_single[2]),
             },
             "single_line_comment": [],
             "cont_single_line_comment": [],

--- a/nirjas/languages/tests/test_perl.py
+++ b/nirjas/languages/tests/test_perl.py
@@ -18,10 +18,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import contSingleLines, readMultiLineDiff, readSingleLine
 from nirjas.languages import perl
-from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class perlTest(unittest.TestCase):
@@ -67,7 +68,8 @@ class perlTest(unittest.TestCase):
                 "total_lines": comment_single[1],
                 "total_lines_of_comments": comment_single[3] + comment_multiline[3],
                 "blank_lines": comment_single[2],
-                "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2]),
+                "sloc": comment_single[1]
+                - (comment_single[3] + comment_multiline[3] + comment_single[2]),
             },
             "single_line_comment": [],
             "cont_single_line_comment": [],

--- a/nirjas/languages/tests/test_php.py
+++ b/nirjas/languages/tests/test_php.py
@@ -18,10 +18,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import contSingleLines, readMultiLineDiff, readSingleLine
 from nirjas.languages import php
-from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class PHPTest(unittest.TestCase):
@@ -67,7 +68,8 @@ class PHPTest(unittest.TestCase):
                 "total_lines": comment_single[1],
                 "total_lines_of_comments": comment_single[3] + comment_multiline[3],
                 "blank_lines": comment_single[2],
-                "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2]),
+                "sloc": comment_single[1]
+                - (comment_single[3] + comment_multiline[3] + comment_single[2]),
             },
             "single_line_comment": [],
             "cont_single_line_comment": [],

--- a/nirjas/languages/tests/test_python.py
+++ b/nirjas/languages/tests/test_python.py
@@ -18,10 +18,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import contSingleLines, readMultiLineSame, readSingleLine
 from nirjas.languages import python
-from nirjas.binder import readSingleLine, readMultiLineSame, contSingleLines
 
 
 class PythonTest(unittest.TestCase):
@@ -68,10 +69,16 @@ class PythonTest(unittest.TestCase):
                 "filename": file[-1],
                 "lang": "Python",
                 "total_lines": comment_single[1],
-                "total_lines_of_comments": comment_single[3] + comment_multi_single[3] + comment_multi_double[3],
+                "total_lines_of_comments": comment_single[3]
+                + comment_multi_single[3]
+                + comment_multi_double[3],
                 "blank_lines": comment_single[2],
-                "sloc": comment_single[1] - (
-                    comment_single[3] + comment_multi_single[3] + comment_multi_double[3] + comment_single[2]
+                "sloc": comment_single[1]
+                - (
+                    comment_single[3]
+                    + comment_multi_single[3]
+                    + comment_multi_double[3]
+                    + comment_single[2]
                 ),
             },
             "single_line_comment": [],

--- a/nirjas/languages/tests/test_r.py
+++ b/nirjas/languages/tests/test_r.py
@@ -18,10 +18,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
-from nirjas.languages import r
+import unittest
+
 from nirjas.binder import readSingleLine
+from nirjas.languages import r
 
 
 class rTest(unittest.TestCase):

--- a/nirjas/languages/tests/test_ruby.py
+++ b/nirjas/languages/tests/test_ruby.py
@@ -18,10 +18,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import contSingleLines, readMultiLineDiff, readSingleLine
 from nirjas.languages import ruby
-from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class RubyTest(unittest.TestCase):
@@ -67,7 +68,8 @@ class RubyTest(unittest.TestCase):
                 "total_lines": comment_single[1],
                 "total_lines_of_comments": comment_single[3] + comment_multiline[3],
                 "blank_lines": comment_single[2],
-                "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2]),
+                "sloc": comment_single[1]
+                - (comment_single[3] + comment_multiline[3] + comment_single[2]),
             },
             "single_line_comment": [],
             "cont_single_line_comment": [],

--- a/nirjas/languages/tests/test_rust.py
+++ b/nirjas/languages/tests/test_rust.py
@@ -18,10 +18,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import contSingleLines, readMultiLineDiff, readSingleLine
 from nirjas.languages import rust
-from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class RustTest(unittest.TestCase):
@@ -67,7 +68,8 @@ class RustTest(unittest.TestCase):
                 "total_lines": comment_single[1],
                 "total_lines_of_comments": comment_single[3] + comment_multiline[3],
                 "blank_lines": comment_single[2],
-                "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2]),
+                "sloc": comment_single[1]
+                - (comment_single[3] + comment_multiline[3] + comment_single[2]),
             },
             "single_line_comment": [],
             "cont_single_line_comment": [],

--- a/nirjas/languages/tests/test_scala.py
+++ b/nirjas/languages/tests/test_scala.py
@@ -18,10 +18,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import contSingleLines, readMultiLineDiff, readSingleLine
 from nirjas.languages import scala
-from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class ScalaTest(unittest.TestCase):
@@ -67,7 +68,8 @@ class ScalaTest(unittest.TestCase):
                 "total_lines": comment_single[1],
                 "total_lines_of_comments": comment_single[3] + comment_multiline[3],
                 "blank_lines": comment_single[2],
-                "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2]),
+                "sloc": comment_single[1]
+                - (comment_single[3] + comment_multiline[3] + comment_single[2]),
             },
             "single_line_comment": [],
             "cont_single_line_comment": [],

--- a/nirjas/languages/tests/test_scss.py
+++ b/nirjas/languages/tests/test_scss.py
@@ -20,10 +20,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import contSingleLines, readMultiLineDiff, readSingleLine
 from nirjas.languages import scss
-from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class ScssTest(unittest.TestCase):
@@ -75,10 +76,16 @@ class ScssTest(unittest.TestCase):
                 "filename": file[-1],
                 "lang": "Scss",
                 "total_lines": comment_single_doubleSlash[1],
-                "total_lines_of_comments": comment_single_doubleSlash[3] + comment_single_tripleSlash[3] + comment_multiline[3],
+                "total_lines_of_comments": comment_single_doubleSlash[3]
+                + comment_single_tripleSlash[3]
+                + comment_multiline[3],
                 "blank_lines": comment_single_doubleSlash[2],
-                "sloc": comment_single_doubleSlash[1] - (
-                    comment_single_doubleSlash[3] + comment_single_tripleSlash[3] + comment_multiline[3] + comment_single_doubleSlash[2]
+                "sloc": comment_single_doubleSlash[1]
+                - (
+                    comment_single_doubleSlash[3]
+                    + comment_single_tripleSlash[3]
+                    + comment_multiline[3]
+                    + comment_single_doubleSlash[2]
                 ),
             },
             "single_line_comment": [],

--- a/nirjas/languages/tests/test_shell.py
+++ b/nirjas/languages/tests/test_shell.py
@@ -18,10 +18,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import contSingleLines, readSingleLine
 from nirjas.languages import shell
-from nirjas.binder import readSingleLine, contSingleLines
 
 
 class ShellTest(unittest.TestCase):

--- a/nirjas/languages/tests/test_sql.py
+++ b/nirjas/languages/tests/test_sql.py
@@ -15,10 +15,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import contSingleLines, readMultiLineDiff, readSingleLine
 from nirjas.languages import sql
-from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class sqlTest(unittest.TestCase):
@@ -64,7 +65,8 @@ class sqlTest(unittest.TestCase):
                 "total_lines": comment_single[1],
                 "total_lines_of_comments": comment_single[3] + comment_multiline[3],
                 "blank_lines": comment_single[2],
-                "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2]),
+                "sloc": comment_single[1]
+                - (comment_single[3] + comment_multiline[3] + comment_single[2]),
             },
             "single_line_comment": [],
             "cont_single_line_comment": [],

--- a/nirjas/languages/tests/test_swift.py
+++ b/nirjas/languages/tests/test_swift.py
@@ -18,10 +18,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import contSingleLines, readMultiLineDiff, readSingleLine
 from nirjas.languages import swift
-from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class SwiftTest(unittest.TestCase):
@@ -67,7 +68,8 @@ class SwiftTest(unittest.TestCase):
                 "total_lines": comment_single[1],
                 "total_lines_of_comments": comment_single[3] + comment_multiline[3],
                 "blank_lines": comment_single[2],
-                "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2]),
+                "sloc": comment_single[1]
+                - (comment_single[3] + comment_multiline[3] + comment_single[2]),
             },
             "single_line_comment": [],
             "cont_single_line_comment": [],

--- a/nirjas/languages/tests/test_typescript.py
+++ b/nirjas/languages/tests/test_typescript.py
@@ -20,10 +20,11 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import unittest
 import os
+import unittest
+
+from nirjas.binder import contSingleLines, readMultiLineDiff, readSingleLine
 from nirjas.languages import typescript
-from nirjas.binder import readSingleLine, readMultiLineDiff, contSingleLines
 
 
 class TSTest(unittest.TestCase):
@@ -69,7 +70,8 @@ class TSTest(unittest.TestCase):
                 "total_lines": comment_single[1],
                 "total_lines_of_comments": comment_single[3] + comment_multiline[3],
                 "blank_lines": comment_single[2],
-                "sloc": comment_single[1] - (comment_single[3] + comment_multiline[3] + comment_single[2]),
+                "sloc": comment_single[1]
+                - (comment_single[3] + comment_multiline[3] + comment_single[2]),
             },
             "single_line_comment": [],
             "cont_single_line_comment": [],

--- a/nirjas/languages/text.py
+++ b/nirjas/languages/text.py
@@ -21,7 +21,7 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-from nirjas.output import ScanOutput, MultiLine
+from nirjas.output import MultiLine, ScanOutput
 
 
 def textExtractor(file):

--- a/nirjas/languages/typescript.py
+++ b/nirjas/languages/typescript.py
@@ -21,7 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from nirjas.binder import CommentSyntax, contSingleLines
-from nirjas.output import ScanOutput, SingleLine, MultiLine
+from nirjas.output import MultiLine, ScanOutput, SingleLine
 
 
 def typescriptExtractor(file):
@@ -97,7 +97,7 @@ def typescriptSource(file, new_file: str):
                     copy = False
                     found = True
                 if "*/" in line:
-                    content = content + line[line.rfind("*/") + 2:]
+                    content = content + line[line.rfind("*/") + 2 :]
                     line = content
                     copy = True
                     found = True

--- a/nirjas/main.py
+++ b/nirjas/main.py
@@ -21,9 +21,9 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import os
-import json
 import argparse
+import json
+import os
 
 from nirjas.languages import *  # noqa
 

--- a/nirjas/output/__init__.py
+++ b/nirjas/output/__init__.py
@@ -23,7 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 Module to hold output classes.
 """
 
-from .scan_output import ScanOutput  # noqa
-from .single_line import SingleLine  # noqa
 from .multi_line import MultiLine  # noqa
 from .output import Output  # noqa
+from .scan_output import ScanOutput  # noqa
+from .single_line import SingleLine  # noqa

--- a/nirjas/output/scan_output.py
+++ b/nirjas/output/scan_output.py
@@ -50,7 +50,8 @@ class ScanOutput:
                 total_lines=self.total_lines,
                 total_lines_of_comments=self.total_lines_of_comments,
                 blank_lines=self.blank_lines,
-                sloc=self.total_lines - (self.total_lines_of_comments + self.blank_lines),
+                sloc=self.total_lines
+                - (self.total_lines_of_comments + self.blank_lines),
             ).output,
             single_line_comment=[c.get_dict() for c in self.single_line_comment],
             cont_single_line_comment=[

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-'''
+"""
 Copyright (C) 2020  Ayush Bhardwaj (classicayush@gmail.com),
 Kaushlendra Pratap (kaushlendrapratap.9837@gmail.com)
 
@@ -16,15 +16,16 @@ Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-'''
+"""
 
-from os import path
 from io import open
-from setuptools import setup, find_packages
+from os import path
+
+from setuptools import find_packages, setup
 
 here = path.abspath(path.dirname(__file__))
 # fetch the long description from the README.md
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+with open(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 CLASSIFIERS = """\
@@ -39,25 +40,20 @@ Topic :: Text Processing
 """
 
 setup(
-    name='Nirjas',
-    version='1.0.1',
-    description='A Python library to extract comments and source code out of your file(s)',
+    name="Nirjas",
+    version="1.0.1",
+    description="A Python library to extract comments and source code out of your file(s)",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/fossology/nirjas',
-    author='Ayush Bhardwaj, Kaushlendra Pratap',
-    author_email='classicayush@gmail.com, kaushlendrapratap.9837@gmail.com',
-
-    classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
-    keywords='Nirjas,Code Comment, Comment Extractor, Code Comment Extractor,' +
-             ' Source Code Extractor, Source Extractor',
+    long_description_content_type="text/markdown",
+    url="https://github.com/fossology/nirjas",
+    author="Ayush Bhardwaj, Kaushlendra Pratap",
+    author_email="classicayush@gmail.com, kaushlendrapratap.9837@gmail.com",
+    classifiers=[_f for _f in CLASSIFIERS.split("\n") if _f],
+    keywords="Nirjas,Code Comment, Comment Extractor, Code Comment Extractor,"
+    + " Source Code Extractor, Source Extractor",
     packages=find_packages(),
     python_requires=">=3",
-    entry_points={
-        'console_scripts': [
-            'nirjas = nirjas.main:run_and_print'
-        ]
-    },
+    entry_points={"console_scripts": ["nirjas = nirjas.main:run_and_print"]},
     license="LGPL-2.1-or-later",
-    platforms=['any']
+    platforms=["any"],
 )

--- a/testScript.py
+++ b/testScript.py
@@ -18,10 +18,10 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
-import urllib.request
-import unittest
-import sys
 import os
+import sys
+import unittest
+import urllib.request
 
 
 def download_files(cwd):


### PR DESCRIPTION
Apologies for the huge delta, this resulted from running [black](https://github.com/psf/black) and [isort](https://github.com/PyCQA/isort) to standardize the code formatting.

Style is a personal thing, so I will leave it to the authors if they want to accept it or not.