### PR TITLE
fix(binder): Use minimum of startLine and endLine

### DIFF
--- a/nirjas/binder.py
+++ b/nirjas/binder.py
@@ -123,16 +123,17 @@ def readMultiLineDiff(file, startSyntax: str, endSyntax: str):
     output, startLine, endLine = [], [], []
     content = ""
     total_lines, line_of_comments, blank_lines = 0, 0, 0
-    copy = False
+    inComment = False
     with open(file) as f:
         for lineNumber, line in enumerate(f, start=1):
             total_lines += 1
-            if startSyntax in line:
-                copy = True
+            stripped_line = line.strip()
+            if startSyntax in stripped_line and not inComment:
+                inComment = True
                 startLine.append(lineNumber)
                 line = line[line.find(startSyntax) + len(startSyntax):]
-            if endSyntax in line:
-                copy = False
+            if endSyntax in stripped_line and inComment:
+                inComment = False
                 line = line[: line.rfind(endSyntax) + len(endSyntax)]
                 content = content + line.replace("\n", " ")
                 content = content.strip(startSyntax).strip(endSyntax).strip()
@@ -140,11 +141,12 @@ def readMultiLineDiff(file, startSyntax: str, endSyntax: str):
                 content = ""
                 endLine.append(lineNumber)
                 continue
-            if copy:
+            if inComment:
                 content = content + (line.replace("\n", " ")).strip()
-            if line.strip() == "":
+            if stripped_line == "":
                 blank_lines += 1
-        for idx, _ in enumerate(endLine):
+        min_length = min(len(startLine), len(endLine))
+        for idx in range(min_length):
             line_of_comments = line_of_comments + (endLine[idx] - startLine[idx]) + 1
         line_of_comments += len(output)
         output = [s.strip(startSyntax).strip(endSyntax).strip() for s in output]


### PR DESCRIPTION
Check valid pairs of startLine and endLine comments before indexing as a list.

Fixes #62


Screenshot of the fix:
<img width="1440" alt="Screenshot 2025-07-06 at 1 21 41 AM" src="https://github.com/user-attachments/assets/daf5a149-1554-4316-9636-86477fb89510" />

