### PR TITLE
ci: Update Python versions and actions in workflow

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -5,19 +5,20 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
-    name: Unit Tests on ${{ matrix.python-version }}
+    name: Unit Tests on Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup python
-        uses: actions/setup-python@v2
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
+
       - name: Run tests
         run: python testScript.py
-


### PR DESCRIPTION
Resolves the CI build failures that occur because the workflow attempts to use end-of-life Python versions (like 3.7) which are no longer available on GitHub's hosted runners.